### PR TITLE
Supprime mentions SGMAP

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,9 +3,9 @@
 
 ## Ajouter une API
 
-### [En un clic par l'interface web de GitHub](https://github.com/sgmap/api.gouv.fr/new/master/_api?filename=_api/nom_api.md&value=---%0D%0Atitle%3A+Ma+Super+API++%23+nom+commercial+de+l%27API%0D%0Atagline%3A+Mission+de+l%27API++%23+une+phrase+maximum%0D%0Aowner%3A+DINSIC++%23+producteur+de+l%27API%0D%0Acategory%3A+confidential++%23+type+de+donn%C3%A9e+expos%C3%A9e%2C+voir+api_category+dans+le+fichier+_config.yml%0D%0Acontract%3A+OUVERT+sous+contrat++%23+peut+%C3%AAtre+%22OUVERT%22+ou+%22OUVERT+sous+contrat%22%0D%0Alogo%3A+https%3A%2F%2Fma-super-api.fr%2Flogo.svg++%23+URL+d%27un+logo+de+l%27API%0D%0Aopenapi_definition%3A+https%3A%2F%2Fma-super-api.fr%2Fspec.yaml+%23+URL+de+la+documentation+au+format+OpenAPI+%3Chttps%3A%2F%2Fgithub.com%2FOAI%2FOpenAPI-Specification%3E%0D%0Acontact%3A++contact%40ma-super-api.fr+%23moyen+de+contact%2C+soit+un+mail%2C+soit+un+lien+vers+formulaire+de+contact%0D%0Adoc_tech%3A+https%3A%2F%2Fma-super-api.fr%2Fdoc++%23+URL+de+la+documentation+technique+de+l%27API+au+format+HTML%0D%0Aaccess_link%3A+https%3A%2F%2Fma-super-api.fr%2Fregister++%23+URL+d%27une+page+de+demande+d%27acc%C3%A8s+si+l%27API+est+%C3%A0+acc%C3%A8s+restreint%0D%0Astat%3A%0D%0A++url%3A+https%3A%2F%2Fma-super-api.fr%2Fstats++%23+adresse+%C3%A0+laquelle+un+nombre+d%27appels+%C3%A0+l%27API+est+publi%C3%A9%2C+en+content-type+application%2Fjson%0D%0A++label%3A+Appels++%23+description+d%27un+appel+%C3%A0+l%27API%0D%0A++lastXdays%3A+30++%23+nombre+de+jours+sur+lequel+les+appels+%C3%A0+l%27API+sont+comptabilis%C3%A9s%0D%0Aclients%3A++%23+types+d%27entit%C3%A9s+habilit%C3%A9es+%C3%A0+utiliser+l%27API%0D%0A++-+particuliers++%23+texte+libre+en+minuscules%0D%0A++-+entreprises++%23+ajoutez+ou+supprimez+des+types+d%27entit%C3%A9s%0D%0A++-+collectivit%C3%A9s%0D%0A++-+minist%C3%A8res%0D%0Apartners%3A++%23+liste+de+co-producteurs+de+l%27API%0D%0A++-+fournisseur+local++%23+texte+libre%0D%0Akeywords%3A+%23+utilis%C3%A9+dans+la+recherche%0D%0A++-+adresse++%23+texte+libre%0D%0A++-+SIRET%0D%0A---%0D%0A%0D%0A%23%23+Description+de+l%27API%0D%0A%0D%0ATexte+libre+au+format+%5BMarkdown%5D%28http%3A%2F%2Fricostacruz.com%2Fcheatsheets%2Fmarkdown.html%29.%0D%0A%0D%0ANe+pas+utiliser+le+premier+niveau+de+titre+%60h1%60+car+il+est+r%C3%A9serv%C3%A9.%0D%0A%0D%0A%23%23+Rappel%0D%0A%0D%0A-+%5B+%5D+Modifier+le+nom+du+fichier+%60nom_api.md%60+dans+le+champ+ci-dessus.%0D%0A-+%5B+%5D+Cr%C3%A9er+une+nouvelle+branche+pour+l%27ajout+de+ce+fichier%2C+et+la+nommer+du+m%C3%AAme+nom+que+le+fichier+%60nom_api%60.%0D%0A-+%5B+%5D+Ouvrir+une+pull+request+pour+valider+l%27int%C3%A9gration.%0D%0A-+%5B+%5D+Effacer+ce+texte+une+fois+que+vous+l%27avez+lu) :smiley:
+### [En un clic par l'interface web de GitHub](https://github.com/betagouv/api.gouv.fr/new/master/_api?filename=_api/nom_api.md&value=---%0D%0Atitle%3A+Ma+Super+API++%23+nom+commercial+de+l%27API%0D%0Atagline%3A+Mission+de+l%27API++%23+une+phrase+maximum%0D%0Aowner%3A+DINSIC++%23+producteur+de+l%27API%0D%0Acategory%3A+confidential++%23+type+de+donn%C3%A9e+expos%C3%A9e%2C+voir+api_category+dans+le+fichier+_config.yml%0D%0Acontract%3A+OUVERT+sous+contrat++%23+peut+%C3%AAtre+%22OUVERT%22+ou+%22OUVERT+sous+contrat%22%0D%0Alogo%3A+https%3A%2F%2Fma-super-api.fr%2Flogo.svg++%23+URL+d%27un+logo+de+l%27API%0D%0Aopenapi_definition%3A+https%3A%2F%2Fma-super-api.fr%2Fspec.yaml+%23+URL+de+la+documentation+au+format+OpenAPI+%3Chttps%3A%2F%2Fgithub.com%2FOAI%2FOpenAPI-Specification%3E%0D%0Acontact%3A++contact%40ma-super-api.fr+%23moyen+de+contact%2C+soit+un+mail%2C+soit+un+lien+vers+formulaire+de+contact%0D%0Adoc_tech%3A+https%3A%2F%2Fma-super-api.fr%2Fdoc++%23+URL+de+la+documentation+technique+de+l%27API+au+format+HTML%0D%0Aaccess_link%3A+https%3A%2F%2Fma-super-api.fr%2Fregister++%23+URL+d%27une+page+de+demande+d%27acc%C3%A8s+si+l%27API+est+%C3%A0+acc%C3%A8s+restreint%0D%0Astat%3A%0D%0A++url%3A+https%3A%2F%2Fma-super-api.fr%2Fstats++%23+adresse+%C3%A0+laquelle+un+nombre+d%27appels+%C3%A0+l%27API+est+publi%C3%A9%2C+en+content-type+application%2Fjson%0D%0A++label%3A+Appels++%23+description+d%27un+appel+%C3%A0+l%27API%0D%0A++lastXdays%3A+30++%23+nombre+de+jours+sur+lequel+les+appels+%C3%A0+l%27API+sont+comptabilis%C3%A9s%0D%0Aclients%3A++%23+types+d%27entit%C3%A9s+habilit%C3%A9es+%C3%A0+utiliser+l%27API%0D%0A++-+particuliers++%23+texte+libre+en+minuscules%0D%0A++-+entreprises++%23+ajoutez+ou+supprimez+des+types+d%27entit%C3%A9s%0D%0A++-+collectivit%C3%A9s%0D%0A++-+minist%C3%A8res%0D%0Apartners%3A++%23+liste+de+co-producteurs+de+l%27API%0D%0A++-+fournisseur+local++%23+texte+libre%0D%0Akeywords%3A+%23+utilis%C3%A9+dans+la+recherche%0D%0A++-+adresse++%23+texte+libre%0D%0A++-+SIRET%0D%0A---%0D%0A%0D%0A%23%23+Description+de+l%27API%0D%0A%0D%0ATexte+libre+au+format+%5BMarkdown%5D%28http%3A%2F%2Fricostacruz.com%2Fcheatsheets%2Fmarkdown.html%29.%0D%0A%0D%0ANe+pas+utiliser+le+premier+niveau+de+titre+%60h1%60+car+il+est+r%C3%A9serv%C3%A9.%0D%0A%0D%0A%23%23+Rappel%0D%0A%0D%0A-+%5B+%5D+Modifier+le+nom+du+fichier+%60nom_api.md%60+dans+le+champ+ci-dessus.%0D%0A-+%5B+%5D+Cr%C3%A9er+une+nouvelle+branche+pour+l%27ajout+de+ce+fichier%2C+et+la+nommer+du+m%C3%AAme+nom+que+le+fichier+%60nom_api%60.%0D%0A-+%5B+%5D+Ouvrir+une+pull+request+pour+valider+l%27int%C3%A9gration.%0D%0A-+%5B+%5D+Effacer+ce+texte+une+fois+que+vous+l%27avez+lu) :smiley:
 
-> Sinon, offline : créer un nouveau fichier de description dans le dossier [`_api`](https://github.com/sgmap/api.gouv.fr/tree/master/_api) et renseigner les informations en prenant exemple sur un fichier de description existant déjà dans ce dossier.
+> Sinon, offline : créer un nouveau fichier de description dans le dossier [`_api`](https://github.com/betagouv/api.gouv.fr/tree/master/_api) et renseigner les informations en prenant exemple sur un fichier de description existant déjà dans ce dossier.
 
 Nous vous recommandons de :
 
@@ -22,35 +22,35 @@ Dans le cas d'API fermées :
 
 ## Ajouter un service
 
-### [En un clic par l'interface web de GitHub](https://github.com/sgmap/api.gouv.fr/new/master/_service?filename=_service/nom_service.md&value=---%0d%0atitle%3a+Mon+Super+Service++%23+texte+libre%0d%0alink%3a+https%3a%2f%2fmon-super-service.fr%0d%0adescription%3a+Une+phrase+devrait+suffire+%c3%a0+pr%c3%a9senter+ce+service.+%23+%c3%a9vitez+de+r%c3%a9p%c3%a9ter+le+nom+du+service%2c+il+sera+indiqu%c3%a9+imm%c3%a9diatement+%c3%a0+c%c3%b4t%c3%a9%0d%0aapi%3a++%23+lister+toutes+les+API+r%c3%a9f%c3%a9renc%c3%a9es+dans+api.gouv.fr+et+utilis%c3%a9es+par+le+service%0d%0a+-+G%c3%a9oAPI++%23+utiliser+le+nom+de+l%27API%0d%0ascreenshot%3a+mon-super-service.jpg++%23+nom+de+fichier+relatif+au+dossier+%2fimg%0d%0a---%0d%0a%0d%0a%23%23+Description+du+service%0d%0a%0d%0aTexte+libre+au+format+%5bMarkdown%5d(http%3a%2f%2fricostacruz.com%2fcheatsheets%2fmarkdown.html).%0d%0a%0d%0a%0d%0a%23%23+Rappel%0d%0a%0d%0a-+%5b+%5d+Modifier+le+nom+du+fichier+%60nom_service.md%60+dans+le+champ+ci-dessus.%0d%0a-+%5b+%5d+Cr%c3%a9er+une+nouvelle+branche+pour+l%27ajout+de+ce+fichier%2c+et+la+nommer+du+m%c3%aame+nom+que+le+fichier+%60nom_service%60.%0d%0a-+%5b+%5d+Ouvrir+une+pull+request+pour+valider+l%27int%c3%a9gration.%0d%0a-+%5b+%5d+Effacer+ce+texte+une+fois+que+vous+l%27avez+lu%0d%0a) :smiley:
+### [En un clic par l'interface web de GitHub](https://github.com/betagouv/api.gouv.fr/new/master/_service?filename=_service/nom_service.md&value=---%0d%0atitle%3a+Mon+Super+Service++%23+texte+libre%0d%0alink%3a+https%3a%2f%2fmon-super-service.fr%0d%0adescription%3a+Une+phrase+devrait+suffire+%c3%a0+pr%c3%a9senter+ce+service.+%23+%c3%a9vitez+de+r%c3%a9p%c3%a9ter+le+nom+du+service%2c+il+sera+indiqu%c3%a9+imm%c3%a9diatement+%c3%a0+c%c3%b4t%c3%a9%0d%0aapi%3a++%23+lister+toutes+les+API+r%c3%a9f%c3%a9renc%c3%a9es+dans+api.gouv.fr+et+utilis%c3%a9es+par+le+service%0d%0a+-+G%c3%a9oAPI++%23+utiliser+le+nom+de+l%27API%0d%0ascreenshot%3a+mon-super-service.jpg++%23+nom+de+fichier+relatif+au+dossier+%2fimg%0d%0a---%0d%0a%0d%0a%23%23+Description+du+service%0d%0a%0d%0aTexte+libre+au+format+%5bMarkdown%5d(http%3a%2f%2fricostacruz.com%2fcheatsheets%2fmarkdown.html).%0d%0a%0d%0a%0d%0a%23%23+Rappel%0d%0a%0d%0a-+%5b+%5d+Modifier+le+nom+du+fichier+%60nom_service.md%60+dans+le+champ+ci-dessus.%0d%0a-+%5b+%5d+Cr%c3%a9er+une+nouvelle+branche+pour+l%27ajout+de+ce+fichier%2c+et+la+nommer+du+m%c3%aame+nom+que+le+fichier+%60nom_service%60.%0d%0a-+%5b+%5d+Ouvrir+une+pull+request+pour+valider+l%27int%c3%a9gration.%0d%0a-+%5b+%5d+Effacer+ce+texte+une+fois+que+vous+l%27avez+lu%0d%0a) :smiley:
 
-> Sinon, offline : créer un nouveau fichier de description dans le dossier [`_service`](https://github.com/sgmap/api.gouv.fr/tree/master/_service) et renseigner les informations en prenant exemple sur un fichier de description existant déjà dans ce dossier.
+> Sinon, offline : créer un nouveau fichier de description dans le dossier [`_service`](https://github.com/betagouv/api.gouv.fr/tree/master/_service) et renseigner les informations en prenant exemple sur un fichier de description existant déjà dans ce dossier.
 
 
 ## Éditer la description d'une API
 
-Modifier le fichier de description de l'API dans le dossier [`_api`](https://github.com/sgmap/api.gouv.fr/tree/master/_api).
+Modifier le fichier de description de l'API dans le dossier [`_api`](https://github.com/betagouv/api.gouv.fr/tree/master/_api).
 
 
 ## Modifier le contenu éditorial
 
-[Rechercher le contenu à modifier](https://github.com/sgmap/api.gouv.fr/search?q=contenu+à+modifier&type=Code) et éditer le fichier correspondant.
+[Rechercher le contenu à modifier](https://github.com/betagouv/api.gouv.fr/search?q=contenu+à+modifier&type=Code) et éditer le fichier correspondant.
 
 
 ## Modifier les types d'API
 
-Mettre à jour la propriété `api_category` dans [`_config.yml`](https://github.com/sgmap/api.gouv.fr/tree/master/_config.yml).
+Mettre à jour la propriété `api_category` dans [`_config.yml`](https://github.com/betagouv/api.gouv.fr/tree/master/_config.yml).
 
 ## Modifier les exemples de recherches
 
-Mettre à jour la propriété `searchExamples` dans [`index.html`](https://github.com/sgmap/api.gouv.fr/tree/master/index.html).
+Mettre à jour la propriété `searchExamples` dans [`index.html`](https://github.com/betagouv/api.gouv.fr/tree/master/index.html).
 
 
 ## Modifier la présentation du site
 
 Ce site est construit avec [Jekyll](https://jekyllrb.com/), un générateur de sites statiques. La version utilisée est celle [actuellement en production](https://github.com/jekyll/jekyll/issues/4441) sur GitHub Pages.
 
-Pour l'améliorer, les informations dans le [README.md](https://github.com/sgmap/api.gouv.fr/blob/master/README.md) permettent d'installer la platforme en local.
+Pour l'améliorer, les informations dans le [README.md](https://github.com/betagouv/api.gouv.fr/blob/master/README.md) permettent d'installer la platforme en local.
 
 Les fichiers pertinents pour une modification de la présentation sont probablement dans les dossiers `_layouts` et `css`.
 
@@ -69,7 +69,7 @@ inkscape --export-text-to-path `pwd`/_sources/logo.svg -l `pwd`/img/logo.svg
 
 ### Prévisualisation (staging)
 
-Chaque pull request est déployée dans Heroku, une fois le [build passé](https://circleci.com/gh/sgmap/api.gouv.fr). Une notification est envoyée sur la pull request :
+Chaque pull request est déployée dans Heroku, une fois le [build passé](https://circleci.com/gh/betagouv/api.gouv.fr). Une notification est envoyée sur la pull request :
 
 ![notification de déploiement en prévisualisation](http://i.imgur.com/7ZuC2Zw.png)
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ api.gouv.fr s'adresse avant tout aux créateurs de services, les consommateurs d
 Les fournisseurs, de leur côté, ont avec ce catalogue un moyen simple de faire connaître leurs API.
 
 
-### Fournisseur d'API ? [Ajoutez votre API](https://github.com/sgmap/api.gouv.fr/blob/master/CONTRIBUTING.md#ajouter-une-api) !
+### Fournisseur d'API ? [Ajoutez votre API](https://github.com/betagouv/api.gouv.fr/blob/master/CONTRIBUTING.md#ajouter-une-api) !
 
-### Réutilisateur d'API ? [Ajoutez votre service](https://github.com/sgmap/api.gouv.fr/blob/master/CONTRIBUTING.md#ajouter-un-service) !
+### Réutilisateur d'API ? [Ajoutez votre service](https://github.com/betagouv/api.gouv.fr/blob/master/CONTRIBUTING.md#ajouter-un-service) !
 
 
 ## Sous-domaines
@@ -25,7 +25,7 @@ Les sous-domaines en `*.api.gouv.fr` hébergent les API cataloguées sur `api.go
 Il est nécessaire de récupérer les sources avec la commande :
 
 ``` sh
-git clone https://github.com/sgmap/api.gouv.fr.git
+git clone https://github.com/betagouv/api.gouv.fr.git
 cd api.gouv.fr
 ```
 
@@ -67,7 +67,7 @@ Le site utilise [Jekyll], un générateur de site statique en [Ruby].
 
 ### Production
 
-Pour déployer ce site, il suffit de pousser les modifications vers la branche `master` sur [github.com/sgmap/api.gouv.fr](https://github.com/sgmap/api.gouv.fr). Cette branche étant protégée, il convient de faire [des pull requests](https://help.github.com/articles/using-pull-requests/) car le projet utilise [GitHub flow](https://guides.github.com/introduction/flow/).
+Pour déployer ce site, il suffit de pousser les modifications vers la branche `master` sur [github.com/betagouv/api.gouv.fr](https://github.com/betagouv/api.gouv.fr). Cette branche étant protégée, il convient de faire [des pull requests](https://help.github.com/articles/using-pull-requests/) car le projet utilise [GitHub flow](https://guides.github.com/introduction/flow/).
 
 
 ### Développement

--- a/_api/api-entreprise.md
+++ b/_api/api-entreprise.md
@@ -34,6 +34,6 @@ keywords:
 access_link: https://tps.apientreprise.fr/users/dossiers/new?procedure_id=33
 ---
 
-L’APIENTREPRISE est une plateforme d’échange opérée par le SGMAP qui met à disposition des opérateurs publics et des administrations, des données et des documents administratifs de référence, relatifs aux entreprises et association, qui sont délivrés par les administrations et les organismes publics, à fin de simplifier les démarches administratives et la gestion des dossiers.
+L’APIENTREPRISE est une plateforme d’échange opérée par la DINSIC qui met à disposition des opérateurs publics et des administrations, des données et des documents administratifs de référence, relatifs aux entreprises et association, qui sont délivrés par les administrations et les organismes publics, à fin de simplifier les démarches administratives et la gestion des dossiers.
 
-Composante de l’Etat plateforme, l’accès à l’APIENTREPRISE est modérée et régulée par le SGMAP, qui attribue à chaque client des autorisations de récupération d’informations selon la nature des démarches à traiter (Marchés publics simplifiés, aides publiques simplifiés…)
+Composante de l’Etat plateforme, l’accès à l’APIENTREPRISE est modérée et régulée par la DINSIC, qui attribue à chaque client des autorisations de récupération d’informations selon la nature des démarches à traiter (Marchés publics simplifiés, aides publiques simplifiés…)

--- a/_api/api-geo.md
+++ b/_api/api-geo.md
@@ -54,7 +54,7 @@ Tout le monde. Mais si vos besoins sont massifs, [contactez-nous](mailto:geo@api
 
 #### Données source
 
-[Toutes les données utilisées](https://github.com/sgmap/api-communes#données-sources) sont sous licences Open Data.
+[Toutes les données utilisées](https://github.com/betagouv/api-communes#données-sources) sont sous licences Open Data.
 
 #### Contact
 

--- a/_api/api-prelevements-sociaux.md
+++ b/_api/api-prelevements-sociaux.md
@@ -1,7 +1,7 @@
 ---
 title: API Prélèvements sociaux
 tagline: Estimer le coût d'embauche en France
-doc_tech: https://github.com/sgmap/cout-embauche/wiki/Documentation-de-l'API-pr%C3%A9l%C3%A8vements-sociaux
+doc_tech: https://github.com/betagouv/cout-embauche/wiki/Documentation-de-l'API-pr%C3%A9l%C3%A8vements-sociaux
 domain: https://embauche.beta.gouv.fr
 contact: contact@embauche.beta.gouv.fr
 contract: OUVERT

--- a/_api/api_etablissements_publics.md
+++ b/_api/api_etablissements_publics.md
@@ -24,6 +24,6 @@ keywords:
 Cette API recense plus de 60 000 guichets publics locaux (mairies, organismes sociaux, services de l'état, etc.). Elle fournit leurs coordonnées (adresses, téléphones, site internet, horaires d'ouverture, coordonnées de géolocalisation) en [Licence Ouverte / Open Licence](https://www.etalab.gouv.fr/licence-ouverte-open-licence).
 
 > Le contenu de cet annuaire est généré automatiquement à partir des données de [Service-public.fr - Annuaire de l’administration - Base de données locales](https://www.data.gouv.fr/fr/datasets/53699fe4a3a729239d206227),
-> par le script d'import disponible sur [github.com/sgmap/annuaire-import](https://github.com/sgmap/annuaire-import)
+> par le script d'import disponible sur [github.com/betagouv/annuaire-import](https://github.com/betagouv/annuaire-import)
 
 >La Base de données locales référence plus de 60 000 guichets publics locaux (mairies, organismes sociaux, services de l'état, etc.). Elle fournit leurs coordonnées (adresses, téléphones, site internet, horaires d'ouverture, coordonnées de géolocalisation). En complément, sont indexés plus de 36 000 fichiers des communes, précisant la compétence géographique des guichets. La liste des types d'organismes référencés dans la base est consultable dans le fichier PDF joint ci-dessous. Le schéma et sa documentation sont disponibles à l'adresse : https://www.service-public.fr/partenaires/comarquage/documentation

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,7 +1,7 @@
 <!-- Piwik -->
 <script type="text/javascript">
   var _paq = _paq || [];
-  _paq.push(["setDomains", ["*.api.gouv.fr","*.sgmap.github.io/api.gouv.fr"]]);
+  _paq.push(["setDomains", ["*.api.gouv.fr","*.betagouv.github.io/api.gouv.fr"]]);
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -23,7 +23,7 @@
             <div class="item">
               <i class="briefcase icon"></i>
               <div class="content">
-                <a href="http://modernisation.gouv.fr/" rel="noopener" target="_blank">Une mission du SGMAP</a>
+                <a href="http://modernisation.gouv.fr/" rel="noopener" target="_blank">Une mission de la DINSIC</a>
               </div>
             </div>
             <div class="item">
@@ -45,7 +45,7 @@
             <div class="item">
               <i class="edit icon"></i>
               <div class="content">
-                <a href="https://github.com/sgmap/api.gouv.fr/edit/master/{{ page.path }}" rel="noopener" target="_blank">Améliorer cette page</a>
+                <a href="https://github.com/betagouv/api.gouv.fr/edit/master/{{ page.path }}" rel="noopener" target="_blank">Améliorer cette page</a>
               </div>
             </div>
           </div>

--- a/ajouter-un-service.md
+++ b/ajouter-un-service.md
@@ -20,7 +20,7 @@ Le service doit être accessible au grand public par internet.
 
 Votre service répond aux critères ci-dessus ? Parfait !
 
-La demande d'ajout au catalogue se fait de manière autonome [via GitHub](https://github.com/sgmap/api.gouv.fr/blob/master/CONTRIBUTING.md). Votre demande sera revue aussi vite que possible, et nous vous aiderons à l'améliorer le cas échéant.
+La demande d'ajout au catalogue se fait de manière autonome [via GitHub](https://github.com/betagouv/api.gouv.fr/blob/master/CONTRIBUTING.md). Votre demande sera revue aussi vite que possible, et nous vous aiderons à l'améliorer le cas échéant.
 
 ## Contact
 

--- a/ajouter-une-api.md
+++ b/ajouter-une-api.md
@@ -38,7 +38,7 @@ Dans tous les cas, il doit être possible de tester l'API sans intervention huma
 
 Votre API répond aux critères ci-dessus ? Parfait !
 
-La demande d'ajout au catalogue se fait de manière autonome [via GitHub](https://github.com/sgmap/api.gouv.fr/blob/master/CONTRIBUTING.md). Votre demande sera revue aussi vite que possible, et nous vous aiderons à l'améliorer le cas échéant.
+La demande d'ajout au catalogue se fait de manière autonome [via GitHub](https://github.com/betagouv/api.gouv.fr/blob/master/CONTRIBUTING.md). Votre demande sera revue aussi vite que possible, et nous vous aiderons à l'améliorer le cas échéant.
 
 ## Contact
 

--- a/app.json
+++ b/app.json
@@ -5,6 +5,6 @@
   "formation": {},
   "addons": [],
   "buildpacks": [{
-    "url": "https://github.com/sgmap/heroku-buildpack-ruby"
+    "url": "https://github.com/betagouv/heroku-buildpack-ruby"
   }]
 }

--- a/contact.md
+++ b/contact.md
@@ -13,7 +13,7 @@ api.gouv.fr se contente de référencer des API existantes. Nous ne pouvons donc
 
 Vous avez repéré un problème ou souhaitez proposer une amélioration du catalogue ?
 
-Vérifiez que cette amélioration ne soit pas [déjà prévue](https://github.com/sgmap/api.gouv.fr/issues) et, si ce n'est pas le cas, [suggérez-la](https://github.com/sgmap/api.gouv.fr/issues/new) sur GitHub !
+Vérifiez que cette amélioration ne soit pas [déjà prévue](https://github.com/betagouv/api.gouv.fr/issues) et, si ce n'est pas le cas, [suggérez-la](https://github.com/betagouv/api.gouv.fr/issues/new) sur GitHub !
 Vous ne savez pas comment faire ? [Écrivez-nous](mailto:contact@api.gouv.fr?subject=Evolution+du+site).
 
 ## Demande de nouvelles API


### PR DESCRIPTION
Remplace le nom d'organisation par `betagouv`.
Remplace le nom de la structure chapeau par DINSIC.