### PR TITLE
Mise à jour de l'URL du service de calcul de quotient familial

### DIFF
--- a/_service/calcul-quotient-familial.md
+++ b/_service/calcul-quotient-familial.md
@@ -1,6 +1,6 @@
 ---
 title: "Lyon : Mon compte"
-link: http://www.lyon.fr/demarches-lyon-en-direct/tourisme-loisirs/loisirs/calcul-du-quotient-familial-municipal.html
+link: https://www.lyon.fr/demarche/loisirs/calcul-du-quotient-familial-municipal
 description: Calcul du quotient familial de la ville de Lyon
 api:
  - API Particulier


### PR DESCRIPTION
Demande de la métropole de Lyon par e-mail.
L'ancienne URL est obsolète.