### PR TITLE
Rétablir le portage d'API particulier / api.gouv.fr

### DIFF
--- a/_api/api-gouv.md
+++ b/_api/api-gouv.md
@@ -7,7 +7,7 @@ clients:
   - Particuliers
   - Enterprises
   - Ministères
-owner: DINSIC
+owner: Incubateur de services numériques (DINSIC)
 layout: api
 logo: logo-generique-startup-carre.jpg
 experimental: true

--- a/_api/api-particulier.md
+++ b/_api/api-particulier.md
@@ -17,7 +17,7 @@ clients:
 partners:
   - DGFiP
   - CNAF
-owner: ETALAB (DINSIC)
+owner: Incubateur de services numériques (DINSIC)
 keywords:
   - Impots
   - CAF


### PR DESCRIPTION
Erreur lors du transfert des autres API à Etalab, API particulier n'était pas dans le lot.