### PR TITLE
Redesign de la page API

### DIFF
--- a/_api/api-particulier.md
+++ b/_api/api-particulier.md
@@ -1,7 +1,6 @@
 ---
 title: API Particulier
 tagline: Simplifiez les démarches de vos usagers, ne demandez plus de justificatifs
-doc_tech: https://particulier.api.gouv.fr/documentation-technique.html
 access_link: https://particulier.api.gouv.fr/charte.html
 domain: https://particulier.api.gouv.fr
 contact: contact@particulier.api.gouv.fr

--- a/_includes/swagger.html
+++ b/_includes/swagger.html
@@ -16,7 +16,9 @@
     plugins: [
       SwaggerUIBundle.plugins.DownloadUrl
     ],
-    layout: "StandaloneLayout"
+    layout: "StandaloneLayout",
+    validatorUrl: null,
+    defaultModelExpandDepth: 0
   })
 
   window.ui = ui

--- a/_layouts/api.html
+++ b/_layouts/api.html
@@ -97,7 +97,7 @@ layout: default
               <div class="description">
                 <ul>
                   {% for partner in page.partners %}
-              			<li>{{ partner }}</li>
+                    <li>{{ partner }}</li>
                   {% endfor %}
                 </ul>
               </div>

--- a/_layouts/api.html
+++ b/_layouts/api.html
@@ -136,7 +136,7 @@ layout: default
       {% assign serviceHtmlWithoutSpace = serviceHtml | strip_newlines | strip %}
       {% if serviceHtmlWithoutSpace != "" %}
       <section id="services" class="ui container">
-        <h2 class="ui divider horizontal">Les services</h2>
+        <h2 class="section-title">Les services</h2>
         <div class="ui two stackable cards">
           {{ serviceHtml }}
         </div>

--- a/_layouts/api.html
+++ b/_layouts/api.html
@@ -13,17 +13,6 @@ layout: default
         <h2 class="ui inverted header">
           {{ page.tagline }}
         </h2>
-        {% if page.doc_tech %}
-        <a class="large ui secondary button" href="{{ page.doc_tech }}" rel="noopener" target="_blank">
-          Documentation technique &nbsp;&nbsp;<i class="code icon"></i>
-        </a>
-        {% endif %}
-        {% if page.access_link %}
-        <a class="large ui secondary button" href="{{ page.access_link }}" rel="noopener" target="_blank">
-          Demandez l'accès &nbsp;&nbsp;
-          <i class="ticket icon"></i>
-        </a>
-        {% endif %}
       </div>
     </div>
   </div>
@@ -106,7 +95,11 @@ layout: default
             <div class="content">
               <div class="header">Sources et partenaires</div>
               <div class="description">
-                {{ page.partners | join: ' - ' }}
+                <ul>
+                  {% for partner in page.partners %}
+              			<li>{{ partner }}</li>
+                  {% endfor %}
+                </ul>
               </div>
             </div>
           </div>
@@ -115,47 +108,45 @@ layout: default
       </div>
     </div>
     <div class="ten wide tablet twelve wide computer column">
-      <div class="ui secondary pointing menu">
-        <a class="item tab active" data-tab="funk">Description</a>
-        <a class="item tab" data-tab="tech">Technique</a>
-      </div>
-      <div class="ui active tab" data-tab="funk">
-        <section class="markdown-body">
+      <section id="description">
+        <h2 class="section-title">Description</h2>
+        <div class="markdown-body" >
           {{ content }}
-        </section>
-      </div>
-      <div class="ui tab" data-tab="tech">
+        </div>
+      </section>
+
+      <section id="technique">
+        <h2 class="section-title">Documentation technique</h2>
         {% if page.openapi_definition %}
-          <section class="ui container">
-            {% include swagger.html %}
-          </section>
+          {% include swagger.html %}
         {% else %}
           <p>
             Vous pouvez retrouver la documentation technique sur <a href="{{ page.doc_tech }}" rel="noopener" target="_blank">le site de l'API</a>
           </p>
         {% endif %}
+      </section>
+
+      {% capture serviceHtml %}
+        {% for service in site.service %}
+          {% if service.api contains page.title%}
+            {% include service-card.html service=service %}
+          {% endif %}
+        {% endfor %}
+      {% endcapture %}
+      {% assign serviceHtmlWithoutSpace = serviceHtml | strip_newlines | strip %}
+      {% if serviceHtmlWithoutSpace != "" %}
+      <section id="services" class="ui container">
+        <h2 class="ui divider horizontal">Les services</h2>
+        <div class="ui two stackable cards">
+          {{ serviceHtml }}
+        </div>
+      </section>
+      {% endif %}
+
       </div>
     </div>
   </div>
 </div>
-
-{% capture serviceHtml %}
-  {% for service in site.service %}
-    {% if service.api contains page.title%}
-      {% include service-card.html service=service %}
-    {% endif %}
-  {% endfor %}
-{% endcapture %}
-{% assign serviceHtmlWithoutSpace = serviceHtml | strip_newlines | strip %}
-{% if serviceHtmlWithoutSpace != "" %}
-<section id="services" class="ui container">
-  <h2 class="ui divider horizontal">Les services</h2>
-  <div class="ui two stackable cards">
-    {{ serviceHtml }}
-  </div>
-</section>
-{% endif %}
-
 
 <script>
   $(function() {

--- a/_layouts/api.html
+++ b/_layouts/api.html
@@ -142,8 +142,6 @@ layout: default
         </div>
       </section>
       {% endif %}
-
-      </div>
     </div>
   </div>
 </div>

--- a/_layouts/api.html
+++ b/_layouts/api.html
@@ -108,7 +108,7 @@ layout: default
       </div>
     </div>
     <div class="ten wide tablet twelve wide computer column">
-      <section id="description">
+      <section id="api-description">
         <h2 class="section-title">Description</h2>
         <div class="markdown-body" >
           {{ content }}

--- a/css/api.scss
+++ b/css/api.scss
@@ -6,6 +6,14 @@
 @import "markdown";
 @import "service";
 
+.section-title {
+  font-size: 1.3em;
+  border-bottom: 1px solid #289fdc;
+}
+
+section + section {
+  margin-top: 2em;
+}
 
 #mission-statement {
   padding-top: 5%;
@@ -60,9 +68,20 @@
     }
   }
   .swagger-section {
+    background-color: whitesmoke;
+    padding: 10px 2em;
+
+    hgroup.main h2 {
+      font-size: 1em;
+    }
     .info_title {
       display: none;
     }
+
+    .swagger-ui .wrapper section.models {
+      background-color: #fff;
+    }
+
   }
 
   #validator {


### PR DESCRIPTION
Pour ne plus avoir d'onglets, car cela nous empêche d'envoyer par email un lien vers la documentation technique.

Dorénavant on peut envoyer http://api.gouv.fr/api/api-particulier.html#technique

