### PR TITLE
Ajoute la terminaison .html au lien de demande d'accès

### DIFF
--- a/_api/api-particulier.md
+++ b/_api/api-particulier.md
@@ -1,7 +1,7 @@
 ---
 title: API Particulier
 tagline: Pour accélérer l’ouverture des données personnelles et leur réutilisation, automatisez vos demandes de pièces justificatives
-access_link: https://signup.api.gouv.fr/api-particulier
+access_link: https://signup.api.gouv.fr/api-particulier.html
 domain: https://particulier.api.gouv.fr
 contact: contact@particulier.api.gouv.fr
 contract: OUVERT sous contrat


### PR DESCRIPTION
Certains proxy ajoutent un "trailing slash" aux URL sans terminaison, ce qui produit un bug avec l'application next liée. Ajouter la terminaison corrige ce dysfonctionnement.