### PR TITLE
Corrections APIs Température et Qualité Rivières

### DIFF
--- a/_api/api_hubeau_qualite_rivieres.md
+++ b/_api/api_hubeau_qualite_rivieres.md
@@ -45,7 +45,8 @@ Quelques statistiques sur les données :
 
 * 18 088 stations ont fait l'objet d'au moins une opération de prélèvement.
 * 1 120 560 opérations de prélèvement sont répertoriées entre 1960 et 2017.
-* Ces opérations de prélèvement ont donné lieu à 125 746 527 analyses concernant 1792 paramètres physico-chimiques différents.</li><li>Le paramètre le plus mesuré est la Température de l'eau (code 1301) avec 1 190 072 analyses.
+* Ces opérations de prélèvement ont donné lieu à 125 746 527 analyses concernant 1792 paramètres physico-chimiques différents.
+* Le paramètre le plus mesuré est la Température de l'eau (code 1301) avec 1 190 072 analyses.
 * L'année comportant le plus de mesures est l'année 2015 où ont eu lieu 59 298 opérations de prélèvement ayant conduit à 13 109 401 analyses.
 * La station la plus suivie est le "Rhône à Arles 2 au Pont de Trinquetaille", de code 06131550, avec 423 481 analyses.
 

--- a/_api/api_hubeau_temperature_rivieres.md
+++ b/_api/api_hubeau_temperature_rivieres.md
@@ -2,8 +2,8 @@
 title: Hub'Eau - Température des cours d'eau (BETA)
 tagline: Température en continu dans les cours d'eau
 contract: OUVERT
-openapi_definition: https://hubeau.eaufrance.fr/api/v1/qualite_rivieres/api-docs
-doc_tech: https://hubeau.eaufrance.fr/api/vbeta/temperature/api-docs
+openapi_definition: https://hubeau.eaufrance.fr/api/vbeta/temperature/api-docs
+doc_tech: https://hubeau.eaufrance.fr/page/documentation-temperature-cours-deau
 logo: 06-temperature_rivieres.png
 contact: newshubeau@brgm.fr
 clients:
@@ -45,6 +45,7 @@ Les données sont exposées sous la forme d'une API REST, les formats supportés
 
 Dernières évolutions de l'API Température en continu des cours d'eau de Hub'Eau:
 
+* 14/06/2018 : publication de la version bêta-1, correction bug chroniques.csv
 * 31/05/2018 : mise à disposition de la version bêta
 
 ### Connaissez-vous Hub'Eau ?


### PR DESCRIPTION
Correction grosse erreur sur url openapi_definition pour Température
Correction typos pour Qualité Rivières