### PR TITLE
fix broken research bar

### DIFF
--- a/_api/franceconnect.md
+++ b/_api/franceconnect.md
@@ -4,9 +4,9 @@ tagline: FranceConnect est un dispositif qui garantit l’identité d’un usage
 external_site: https://franceconnect.gouv.fr/partenaires
 contract: OUVERT sous contrat
 clients:
-  - Particuliers, pour contacter FranceConnect, <a href="mailto:support@franceconnect.gouv.fr">cliquez ici</a>
-  - Entreprises, si vous avez vérifié votre éligibilité, vous pouvez demander à <a href="https://signup.api.gouv.fr/franceconnect">intégrer le bouton FranceConnect</a>.
-  - Collectivités, vous souhaitez intégrer le bouton FranceConnect, <a href="https://signup.api.gouv.fr/franceconnect">faites votre demande d'accès</a>
+  - Particuliers, pour contacter FranceConnect, <a href='mailto:support@franceconnect.gouv.fr'>cliquez ici</a>
+  - Entreprises, si vous avez vérifié votre éligibilité, vous pouvez demander à <a href='https://signup.api.gouv.fr/franceconnect'>intégrer le bouton FranceConnect</a>.
+  - Collectivités, vous souhaitez intégrer le bouton FranceConnect, <a href='https://signup.api.gouv.fr/franceconnect'>faites votre demande d'accès</a>
 partners:
   - DGFiP
   - IDN


### PR DESCRIPTION
The double quote character in the client section breaks the search
feature. This commit fixes the search without finding the root cause.