### PR TITLE
Proposition de changement de baseline

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@
 title: api.gouv.fr
 baseurl: ""
 url: "https://api.gouv.fr"
-description: Fabriquez des services en ligne plus simples
+description: Un accès unique aux API de l'État
 menu_options: [
   {
     id: "access",


### PR DESCRIPTION
La baseline actuelle: "Fabriquez des services en ligne plus simples" est trop large et ne permet pas de distinguer d'autres offres de services de l'administration, par exemple "Nous créons des services publics numériques" pour beta.gouv.fr