### PR TITLE
Mise à jour du lien pour le dossier social étudiant

### DIFF
--- a/_service/dossier-social-etudiant.md
+++ b/_service/dossier-social-etudiant.md
@@ -1,6 +1,6 @@
 ---
 title: Dossier Social Étudiant
-link: https://www.messervices.etudiant.gouv.fr/envole/portal/index.php#
+link: https://www.messervices.etudiant.gouv.fr/envole/
 description: Le Dossier Social Etudiant permet aux étudiants de candidater aux bourses et aux logements sociaux
 screenshot: dse-etudiant.png
 api:


### PR DESCRIPTION
Le lien actuel renvoie une erreur, changer par la nouvelle adresse du site du DSE.