### PR TITLE
Classement des APIs par ordre décroissant de visite en 2019

### DIFF
--- a/_api/API_Ingres.md
+++ b/_api/API_Ingres.md
@@ -34,6 +34,7 @@ score:
       link: https://api.cisirh.rie.gouv.fr/ingres/nomenclatures
     doc_tech:
       external: http://pissarho.cisirh.rie.gouv.fr/sites/default/files/2019-10/INGRES-PIL-API%20Nomenclatures%20Ingres_%20%280_7%29.pptx
+visits_2019: 127
 ---
 L’API Nomenclature permet d’accéder à toutes les nomenclatures noyau gérées dans l’application Ingres du CISIRH, soit plus de 350 nomenclatures accessibles.
 

--- a/_api/DILA_api_Legifrance.md
+++ b/_api/DILA_api_Legifrance.md
@@ -33,6 +33,7 @@ score:
       link: retours-legifrance-modernise@dila.gouv.fr
     doc_tech:
       external: https://developer.aife.economie.gouv.fr
+visits_2019: 0
 ---
 
 Afin de faciliter la réutilisation des données juridiques, la DILA met à disposition une API via [le portail PISTE](https://developer.aife.economie.gouv.fr/). Cette API est accessible gratuitement, après inscription.

--- a/_api/LaBonneBoite.md
+++ b/_api/LaBonneBoite.md
@@ -33,6 +33,7 @@ score:
       link: https://www.emploi-store-dev.fr/portail-developpeur/detailapicatalogue/57909ba23b2b8d019ee6cc5f
     doc_tech:
       external: https://www.emploi-store-dev.fr/portail-developpeur-cms/home/catalogue-des-api/documentation-des-api/api/api-la-bonne-boite-v1.html
+visits_2019: 2397
 ---
 
 La Bonne Boite cible les entreprises ayant des perspectives d'embauche élevées et permet d’être plus efficace dans l’envoi de candidatures spontanées. Ce ciblage est obtenu par l'analyse de millions de recrutements sur toutes les entreprises françaises. L’API La Bonne Boite permet de récupérer la liste des entreprises classées par potentiel d'embauche pour un métier (code ROME) et/ou activité (code NAF) donné, pour une localisation donnée.

--- a/_api/Sandre-Referentiel-V1_api.md
+++ b/_api/Sandre-Referentiel-V1_api.md
@@ -39,6 +39,7 @@ score:
       link:  # URL d'une page qui affiche le statut
       description: |
         <p>L'OIEau s’engage à ce que ce service soit accessible à 95% et l'OIEau s’engage à améliorer progressivement ce rendement.</p>
+visits_2019: 122
 ---
 
 ## Description de l'API

--- a/_api/api-camino.md
+++ b/_api/api-camino.md
@@ -38,6 +38,7 @@ score:
       link: camino@beta.gouv.fr
     doc_tech:
       external: https://api.camino.beta.gouv.fr
+visits_2019: 41
 ---
 
 L'__API Camino__ offre un accès à l'ensemble des données publiques administratives relatives aux projets miniers, sur l'ensemble du territoire national sur lequel l'Etat dispose de la compétence minière, dans un format ouvert et réutilisable. 

--- a/_api/api-entreprise.md
+++ b/_api/api-entreprise.md
@@ -47,6 +47,7 @@ score:
       external: https://doc.entreprise.api.gouv.fr
     monitoring:
       link: https://dashboard.entreprise.api.gouv.fr
+visits_2019: 12610
 ---
 
 [L’API Entreprise](https://entreprise.api.gouv.fr/) est une plateforme d’échange opérée par la DINUM qui met à disposition des opérateurs publics et des administrations, des données et des documents administratifs de référence, relatifs aux entreprises et association, qui sont délivrés par les administrations et les organismes publics, à fin de simplifier les démarches administratives et la gestion des dossiers.

--- a/_api/api-geo.md
+++ b/_api/api-geo.md
@@ -38,6 +38,7 @@ score:
     rate_limiting:
       description: |
         <p>L'API est disponible à hauteur de 10 appels par seconde et par adresse IP.</p>
+visits_2019: 26602
 ---
 
 L' __API Géo__ est une boîte-à-outils __facile à prendre en main__ pour rendre vos applications et bases de données plus intelligentes, en terme de positionnement et de connaissance des territoires.

--- a/_api/api-particulier.md
+++ b/_api/api-particulier.md
@@ -13,7 +13,8 @@ clients:
 partners:
   - DGFiP
   - CNAF
-owner: Incubateur de services numériques (DINUM)
+owner: Direction interministérielle du numérique
+owner_acronym: DINUM
 keywords:
   - Impots
   - Quotient Familial
@@ -40,6 +41,7 @@ score:
       link: https://status.particulier.api.gouv.fr
       description: |
         <p>La DINUM s’engage à ce que le Service soit accessible à 95% et la DINUM s’engage à améliorer progressivement ce rendement.</p>
+visits_2019: 8642
 ---
 
 ## Vos démarches sans pièces justificatives

--- a/_api/api_Infotravail.md
+++ b/_api/api_Infotravail.md
@@ -26,6 +26,7 @@ score:
       link: https://www.emploi-store-dev.fr/portail-developpeur/detailapicatalogue/57909ba23b2b8d019ee6cc5e
     doc_tech:
       external: https://www.emploi-store-dev.fr/portail-developpeur-cms/home/catalogue-des-api/documentation-des-api/api/api-infotravail-v1.html
+visits_2019: 953
 ---
 
 ## Description de l'API

--- a/_api/api_ameli_droits_cnam.md
+++ b/_api/api_ameli_droits_cnam.md
@@ -43,6 +43,7 @@ score:
       link: https://stats.uptimerobot.com/3wEv6hppvv
       description: |
         <p>Une supervision du service en temps réel est disponible à cette adresse.</p>
+visits_2019: 576
 ---
 
 ## API attestation de droits à l'Assurance Maladie

--- a/_api/api_carto.md
+++ b/_api/api_carto.md
@@ -37,6 +37,7 @@ keywords:
   - rge
   - Géoportail
   - API Carto
+visits_2019: 2 840
 ---
 
 L’API Carto est une API REST compatible avec la spécification OpenAPI permettant d'accéder simplement à des données de référence : urbanisme, cadastre, AOC, codes postaux, etc.

--- a/_api/api_etablissements_publics.md
+++ b/_api/api_etablissements_publics.md
@@ -23,6 +23,7 @@ score:
       link: contact@beta.gouv.fr
     doc_tech:
       link: https://etablissements-publics.api.gouv.fr/v3/definitions.yaml
+visits_2019: 2089
 ---
 
 ## Annuaire des établissements publics de l'administration

--- a/_api/api_hubeau_hydrometrie.md
+++ b/_api/api_hubeau_hydrometrie.md
@@ -39,6 +39,7 @@ score:
       link: newshubeau@brgm.fr
     doc_tech:
       link: https://hubeau.eaufrance.fr/api/v1/hydrometrie/api-docs
+visits_2019: 801
 ---
 
 ### Description fonctionnelle de l'API Hydrométrie

--- a/_api/api_hubeau_indic_EP_Asst.md
+++ b/_api/api_hubeau_indic_EP_Asst.md
@@ -29,6 +29,7 @@ score:
       link: newshubeau@brgm.fr
     doc_tech:
       link: https://hubeau.eaufrance.fr/api/v0/indicateurs_services/api-docs
+visits_2019: 430
 ---
 
 ### Description fonctionnelle de l'API Indicateurs eau potable et assainissement

--- a/_api/api_hubeau_piezometrie.md
+++ b/_api/api_hubeau_piezometrie.md
@@ -36,6 +36,7 @@ score:
       link: newshubeau@brgm.fr
     doc_tech:
       link: https://hubeau.eaufrance.fr/api/v1/niveaux_nappes/api-docs
+visits_2019: 328
 ---
 
 ### Description fonctionnelle de l'API Piézométrie

--- a/_api/api_hubeau_poissons.md
+++ b/_api/api_hubeau_poissons.md
@@ -27,6 +27,7 @@ score:
       link: newshubeau@brgm.fr
     doc_tech:
       link: https://hubeau.eaufrance.fr/api/v0/etat_piscicole/api-docs
+visits_2019: 568
 ---
 
 ### Description fonctionnelle de l'API Poissons

--- a/_api/api_hubeau_prelevements.md
+++ b/_api/api_hubeau_prelevements.md
@@ -27,6 +27,7 @@ score:
       link: newshubeau@brgm.fr
     doc_tech:
       link: https://hubeau.eaufrance.fr/api/v1/prelevements/api-docs
+visits_2019: 55
 ---
 
 ### Description fonctionnelle de l'API Prélèvements en eau

--- a/_api/api_hubeau_qualite_nappes_eau_sout.md
+++ b/_api/api_hubeau_qualite_nappes_eau_sout.md
@@ -29,6 +29,7 @@ score:
       link: newshubeau@brgm.fr
     doc_tech:
       link: https://hubeau.eaufrance.fr/api/v1/qualite_nappes/api-docs
+visits_2019: 381
 ---
 
 ### Description fonctionnelle de l'API Qualité des nappes d'eau souterraine

--- a/_api/api_hubeau_qualite_rivieres.md
+++ b/_api/api_hubeau_qualite_rivieres.md
@@ -29,6 +29,7 @@ score:
       link: newshubeau@brgm.fr
     doc_tech:
       link: https://hubeau.eaufrance.fr/api/v1/qualite_rivieres/api-docs
+visits_2019: 509
 ---
 
 ### Description fonctionnelle de l'API Qualité des cours d'eau

--- a/_api/api_hubeau_temperature_rivieres.md
+++ b/_api/api_hubeau_temperature_rivieres.md
@@ -30,6 +30,7 @@ score:
       link: newshubeau@brgm.fr
     doc_tech:
       link: https://hubeau.eaufrance.fr/api/v1/temperature/api-docs
+visits_2019: 2868
 ---
 
 ### Description fonctionnelle de l'API Température en continu des cours d'eau

--- a/_api/api_look4.md
+++ b/_api/api_look4.md
@@ -25,6 +25,7 @@ score:
       link: http://professionnels.ign.fr/ign/contrats
     contact:
       link: contact.geoservices@ign.fr
+visits_2019: 1266
 ---
 
 # API Look4 Géoportail

--- a/_api/api_menj.md
+++ b/_api/api_menj.md
@@ -27,6 +27,7 @@ keywords:
   - organisation
   - finances
   - personnels
+visits_2019: 37
 ---
 
 Dans le contexte du vaste mouvement d’ouverture et de partage des données publiques tant au niveau interministériel, qu’au niveau des collectivités territoriales, avec une circulation facilitée des données entre tous les acteurs (administrations centrales, services de l’État en régions, collectivités territoriales, secteur privé, etc.), le ministère amplifie cette démarche volontariste pour ouvrir et partager de nouvelles données publiques sur l’enseignement scolaire, en lien étroit avec celle déjà ouverte de l’enseignement supérieur et de la recherche.

--- a/_api/api_offresdemplois.md
+++ b/_api/api_offresdemplois.md
@@ -24,6 +24,7 @@ score:
       link: https://www.emploi-store-dev.fr/portail-developpeur/detailapicatalogue/5ba49d55243a5f9d2c5064a2
     doc_tech:
       link: https://www.emploi-store-dev.fr/portail-developpeur-cms/home/catalogue-des-api/documentation-des-api/api/api-offres-demploi-v2.html
+visits_2019: 1227
 ---
 
 ## Description de l'API

--- a/_api/arpent-resultats-api.md
+++ b/_api/arpent-resultats-api.md
@@ -31,6 +31,7 @@ score:
       link: arpent-resultat.sg@agriculture.gouv.fr
     doc_tech:
       link: https://ensagri.agriculture.gouv.fr/arpent-resultats-api/v2/api-docs?group=arpent-resultats
+visits_2019: 2050
 ---
 
 ### Pourquoi ?

--- a/_api/base-adresse-nationale.md
+++ b/_api/base-adresse-nationale.md
@@ -36,6 +36,7 @@ score:
       description: |
         <p>L'API unitaire est disponible à hauteur de 10 appels par seconde et par adresse IP.</p>
         <p>Le géocodage de masse (CSV) est disponible à hauteur d'un appel simultané par adresse IP.</p>
+visits_2019: 6460
 ---
 
 Pour que les services d'urgence arrivent au bon endroit, pour vous permettre de réaliser une analyse cartographique en quelques clics ou encore pour que les opérateurs publics et privés coordonnent mieux leurs chantiers, ce référentiel, véritable enjeu de souveraineté pour la France, est la première alliance entre l'État et la société civile.

--- a/_api/boamp.md
+++ b/_api/boamp.md
@@ -15,6 +15,7 @@ score:
       link: donnees-dila@dila.gouv.fr
     doc_tech:
       external: http://api.dila.fr
+visits_2019: 1332
 ---
 
 ### Contenu des données

--- a/_api/brest.md
+++ b/_api/brest.md
@@ -22,6 +22,7 @@ score:
       link: mobilites@brest-metropole.fr
     doc_tech:
       external: https://geo.pays-de-brest.fr/donnees/Documents/Public/DocWebServicesTransport.pdf
+visits_2019: 450
 ---
 
 ## Description de l'API

--- a/_api/chorus-pro.md
+++ b/_api/chorus-pro.md
@@ -27,6 +27,7 @@ score:
       link: api-choruspro.aife@finances.gouv.fr
     doc_tech:
       external: https://communaute.chorus-pro.gouv.fr/documentation/api/
+visits_2019: 40978
 ---
 
 ## Qu’est-ce que Chorus Pro ?

--- a/_api/franceconnect.md
+++ b/_api/franceconnect.md
@@ -28,6 +28,7 @@ score:
       link: support.partenaires@franceconnect.gouv.fr
     doc_tech:
       external: https://partenaires.franceconnect.gouv.fr/fcp/fournisseur-service
+visits_2019: 120883
 ---
 
 ## Qu'est-ce que FranceConnect ?

--- a/_api/ift.md
+++ b/_api/ift.md
@@ -30,6 +30,7 @@ score:
       link: calculette-ift.dgpaat@agriculture.gouv.fr
     doc_tech:
       link: https://alim.agriculture.gouv.fr/ift-api/v2/api-docs?group=ift
+visits_2019: 324
 ---
 
 ## Description de l'API

--- a/_api/impot-particulier.md
+++ b/_api/impot-particulier.md
@@ -35,6 +35,7 @@ score:
       link: https://signup.api.gouv.fr/api-impot-particulier
     doc_tech:
       link: https://particulier.api.gouv.fr/swagger_api_impots_particulier.yaml
+visits_2019: 1324
 ---
 
 ## Récupérez les informations fiscales nécessaires à votre téléservice directement auprès de la DGFiP

--- a/_api/le-taxi.md
+++ b/_api/le-taxi.md
@@ -26,6 +26,7 @@ score:
       link: http://le.taxi/join.html
     doc_tech:
       link: https://api.taxi/swagger.json
+visits_2019: 1477
 ---
 
 Grâce à la réunion des taxis au sein d'une plateforme unique, les éditeurs d'applications mobiles peuvent désormais offrir un bouton "le.Taxi" qui permet de visualiser et de héler électroniquement tous les taxis connectés, partout en France. Les usagers peuvent désormais effectuer une commande immédiate d'un taxi à partir de leur smartphone, depuis une des nombreuses applications agréées, qu'il s'agisse d'un moteur de recherche, d'une application de mobilité ou d'une application d'une compagnie de taxi. Avec la même application, ils peuvent trouver un taxi partout en France.

--- a/_api/nomenclatures_v1.md
+++ b/_api/nomenclatures_v1.md
@@ -24,6 +24,7 @@ score:
       link: https://api.insee.fr/catalogue/site/themes/wso2/subthemes/insee/pages/help.jag#contact
     doc_tech:
       link: https://api.insee.fr/catalogue/api-docs/carbon.super/Nomenclatures/v1?envName=Production%20and%20Sandbox
+visits_2019: 727
 ---
 
 L'API Nomenclatures donne accès aux métadonnées statistiques de la statistique publique.

--- a/_api/openfisca.md
+++ b/_api/openfisca.md
@@ -29,6 +29,7 @@ score:
       is_open: true
     doc_tech:
       external: https://openfisca.org/doc/openfisca-web-api/
+visits_2019: 1982
 ---
 
 ## Calculer le droit

--- a/_api/rennesmetropole-rva.md
+++ b/_api/rennesmetropole-rva.md
@@ -20,6 +20,7 @@ score:
       link: http://rva.data.rennes-metropole.fr/inscription.php
     doc_tech:
       external: http://rva.data.rennes-metropole.fr/documentation.php
+visits_2019: 160
 ---
 
 ## Présentation

--- a/_api/rennesmetropole-travaux.md
+++ b/_api/rennesmetropole-travaux.md
@@ -17,6 +17,7 @@ score:
   detail:
     doc_tech:
       external: http://travaux.data.rennesmetropole.fr/
+visits_2019: 315
 ---
 
 ## Présentation

--- a/_api/sirene_v3.md
+++ b/_api/sirene_v3.md
@@ -24,6 +24,7 @@ score:
       link: https://api.insee.fr/catalogue/site/themes/wso2/subthemes/insee/pages/help.jag#contact
     doc_tech:
       link: https://api.insee.fr/catalogue/api-docs/carbon.super/Sirene/V3?envName=Production%20and%20Sandbox
+visits_2019: 3785
 ---
 
 API Sirene donne accès aux informations concernant les entreprises et les établissements immatriculés au répertoire interadministratif Sirene depuis sa création en 1973, y compris les unités fermées.

--- a/_api/temps_reel_transport.md
+++ b/_api/temps_reel_transport.md
@@ -22,6 +22,7 @@ score:
       link: contact@transport.beta.gouv.fr
     doc_tech:
       link: https://tr.transport.data.gouv.fr/spec
+visits_2019: 1346
 ---
 
 ## Description de l'API

--- a/_api/trefle.md
+++ b/_api/trefle.md
@@ -14,7 +14,7 @@ score:
       link: https://www.emploi-store-dev.fr/portail-developpeur/detailapicatalogue/simulateur-de-financement-v1?id=5ca702c8243a5f418929f589
     doc_tech:
       external: https://www.emploi-store-dev.fr/portail-developpeur-cms/home/catalogue-des-api/documentation-des-api/api/api-simulateur-de-financement-v1.html
-
+visits_2019: 80
 ---
 
 ## Description de l'API

--- a/_api/webstat.md
+++ b/_api/webstat.md
@@ -33,7 +33,7 @@ score:
       link: https://developer.webstat.banque-france.fr/contact #moyen de contact, soit un mail, soit un lien vers formulaire de contact
     doc_tech:
       link: https://developer.webstat.banque-france.fr/ibm_apim/swaggerjson/d2Vic3RhdC1iYW5xdWUtZGUtZnJhbmNlLWZyX3YxOjEuMC4wXzQ3MDE%2C # URL de la documentation au format OpenAPI <https://github.com/OAI/OpenAPI-Specification>
-
+visits_2019: 8
 ---
 
 [Webstat](http://webstat.banque-france.fr/fr/) est le portail statistique de la Banque de France. L'[API Webstat](https://developer.webstat.banque-france.fr) permet d'accéder à plus de 35.000 séries statistiques de la Banque de France et de ses partenaires institutionnels. Obtenez simplement les données économiques et financières sur les entreprises françaises, la conjoncture régionale, le crédit et l'épargne, la monnaie ou la balance des paiements.

--- a/build-dataset.js
+++ b/build-dataset.js
@@ -15,6 +15,7 @@ function apiToAPIV1(api) {
     domain: api.domain,
     owner: api.owner,
     contract: api.contract,
+    visits_2019: api.visits_2019,
     keywords: api.keywords,
     clients: api.clients,
     partners: api.partners

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import getConfig from "next/config";
+import { orderBy } from "lodash";
 
 import withErrors from "../components/hoc/with-errors";
 
@@ -54,7 +55,9 @@ function Home({ q, filter, apiList }) {
         <div className="ui container">
           <div className="ui three stackable cards">
             {filteredList.length > 0 ? (
-              filteredList.map(api => <ApiCard key={api.title} {...api} />)
+              orderBy(filteredList, "visits_2019", "desc").map(api => (
+                <ApiCard key={api.title} {...api} />
+              ))
             ) : (
               <div className="ui big warning message">
                 <div className="header">Aucune API n’a pu être trouvée</div>


### PR DESCRIPTION
## Évolutions
- Ajout de `visits_2019` dans les fiches des APIs
- Modification de `/api/v1` pour ajouter `visits_2019`
- Tri la liste des APIs par ordre décroissant de leurs visites en 2019

Fix #410 