### PR TITLE
Réduit la taille de l'en-tête de la page API

### DIFF
--- a/components/api/header.js
+++ b/components/api/header.js
@@ -40,7 +40,7 @@ const Header = ({
           <img
             src={`/images/api-logo/${logo}`}
             alt={title}
-            className="ui small bordered image"
+            className="ui tiny bordered image"
           />
           <h1>{title}</h1>
           <div className="sub header">{tagline}</div>
@@ -85,32 +85,20 @@ const Header = ({
 
       <style jsx>{`
         #mission-statement {
-          padding-top: 5%;
-          padding-bottom: 5%;
-          margin-bottom: 2%;
           background: ${colors.backgroundBlue};
         }
 
         #mission-statement h1 {
-          margin: 0;
+          margin: 0.2em;
         }
 
-        #mission-statement h2 {
-          padding: 0.2em 0;
-        }
-
-        #mission-statement .large.ui.secondary.button {
-          margin: 10px;
-        }
-
-        .sub.header .stat {
+         .sub.header .stat {
           color: white;
           font-size: 1.4em;
           margin-top: 1em;
         }
 
         #stat_value {
-          font-size: 2em;
           margin-bottom: 0.7em;
         }
       `}</style>


### PR DESCRIPTION
## Avant
![Capture d’écran 2020-01-22 à 17 06 56](https://user-images.githubusercontent.com/7040549/72911045-b78b2080-3d39-11ea-97b8-6836a78e6742.png)

## Après
![Capture d’écran 2020-01-22 à 17 06 44](https://user-images.githubusercontent.com/7040549/72911061-bc4fd480-3d39-11ea-86b3-3de7af29a4ea.png)

Fix #414 
