### PR TITLE
Changement du titre

### DIFF
--- a/_data/guides/ccas.md
+++ b/_data/guides/ccas.md
@@ -1,5 +1,5 @@
 ---
-title: Dématérialiser l'instruction des dossiers dans un CCAS
+title: Simplifier l'instruction des dossiers dans un CCAS
 tagline: Vous êtes un CCAS ou un éditeur de logiciel ? Accédez facilement aux données de la CAF et de la DGFIP grâce à l'API Particulier et notre  accompagnement pas à pas.
 tags: cas usage, api particulier, CCAS
 image: dossier.jpg


### PR DESCRIPTION
Changement de titre, passage de "Dématérialiser" à "Simplifier" car la réalité terrain des CCAS c'est pas tant la démat que la récup automatique souvent en physique de données certifiées sans faute de frappe et pour éviter la fraude