### PR TITLE
Added link to support.data.gouv.fr for the data.gouv.fr API

### DIFF
--- a/_data/api/api_data_gouv.md
+++ b/_data/api/api_data_gouv.md
@@ -21,7 +21,7 @@ themes:
   - Géographie
   - Particulier
   - Transport
-contact_link: support@data.gouv.fr
+contact_link: https://support.data.gouv.fr/
 doc_tech_link: https://www.data.gouv.fr/api/1/swagger.json
 doc_tech_external: https://doc.data.gouv.fr/api/reference/
 datagouv_uuid:


### PR DESCRIPTION
The contact button for the data.gouv.fr API now redirects to the support platform support.data.gouv.fr and not to the (deprecated) support email