### PR TITLE
Analytics/parcours demande acces

### DIFF
--- a/components/questionTree/index.tsx
+++ b/components/questionTree/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, Fragment } from 'react';
 import constants from '../../constants';
+import { logParcoursDemandeAcces } from '../../utils/client/analytics';
 import RichReactMarkdown from '../richReactMarkdown';
 import { allQuestions } from './data';
 
@@ -17,7 +18,8 @@ interface IChoiceType {
 const Question: React.FC<{
   questionTree: IQuestionTree;
   parentLabel?: string;
-}> = ({ questionTree, parentLabel }) => {
+  apiName?: string;
+}> = ({ questionTree, parentLabel, apiName }) => {
   const [currentChoiceType, setChoiceType] = useState<IChoiceType | null>(null);
   const [selectedLabel, setSelectedLabel] = useState<string | undefined>(
     undefined
@@ -38,6 +40,11 @@ const Question: React.FC<{
                 key={choice}
                 onClick={() => {
                   setSelectedLabel(choice);
+                  logParcoursDemandeAcces(
+                    '3. Renseigne un sujet de question',
+                    formatCategoryName(apiName),
+                    choice
+                  );
                   setChoiceType(choiceType);
                 }}
                 className={choice === selectedLabel ? 'selected' : ''}
@@ -54,6 +61,7 @@ const Question: React.FC<{
       )}
       {currentChoiceType && currentChoiceType.next && (
         <Question
+          apiName={apiName}
           questionTree={currentChoiceType.next}
           parentLabel={selectedLabel}
         />
@@ -104,11 +112,25 @@ const QuestionTree: React.FC<{ tree: string; question: string }> = ({
   question,
 }) => {
   if (allQuestions[tree] && allQuestions[tree][question]) {
-    return <Question questionTree={allQuestions[tree][question]} />;
+    return (
+      <Question apiName={tree} questionTree={allQuestions[tree][question]} />
+    );
   } else {
     throw new Error(
       `QuestionTree must be called with an existing key, but received : ${tree} and then ${question},`
     );
+  }
+};
+
+// Category name for analytics should be the API title
+const formatCategoryName = (title: string | undefined) => {
+  switch (title) {
+    case 'api-entreprise':
+      return 'API Entreprise';
+    case 'france-connected-api':
+      return 'FranceConnect et les API FranceConnectées';
+    default:
+      return '*';
   }
 };
 

--- a/pages/les-api/[slug].tsx
+++ b/pages/les-api/[slug].tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { GetStaticProps, GetStaticPaths } from 'next';
+import { logParcoursClient } from '../../utils/client/analytics';
 
 import {
   getAPI,

--- a/pages/les-api/[slug]/demande-acces.tsx
+++ b/pages/les-api/[slug]/demande-acces.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { GetStaticProps, GetStaticPaths } from 'next';
 import RichReactMarkdown from '../../../components/richReactMarkdown';
+import { logParcoursDemandeAcces } from '../../../utils/client/analytics';
 
 import {
   getAPI,
@@ -74,6 +75,18 @@ const AccessCondition: React.FC<IProps> = ({
 
     window.setTimeout(() => setIsLoading(false), 500);
   };
+
+  useEffect(() => {
+    if (visitorType === null) {
+      logParcoursDemandeAcces('1. Commence le parcours client', title);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (visitorType !== null) {
+      logParcoursDemandeAcces('2. Renseigne un statut de visiteur', title, visitorType);
+    }
+  }, [visitorType]);
 
   return (
     <Page

--- a/utils/client/analytics.js
+++ b/utils/client/analytics.js
@@ -42,6 +42,17 @@ const logParcoursClient = (step, value = '*') => {
   }
 };
 
+const logParcoursDemandeAcces = (step, api = '*', value = '*') => {
+  if (typeof window !== 'undefined' && window._paq) {
+    window._paq.push([
+      'trackEvent',
+      `Parcours API - ${api}`,
+      step,
+      `valeur : ${value}`,
+    ]);
+  }
+};
+
 const logFeedback = answer => {
   if (typeof window !== 'undefined' && window._paq) {
     window._paq.push([
@@ -69,6 +80,7 @@ export {
   logDemanderAcces,
   logLPCTA,
   logParcoursClient,
+  logParcoursDemandeAcces,
   logFeedback,
   logFeedbackDetails,
 };


### PR DESCRIPTION
Log des événements dans une catégorie 'Parcours Demande Accès - (titre de l'API)'

Evenements:
- Début demande accès
- Type visiteur
- Choix dans le QuestionTree

@XavierJp  Est-ce que le matomo log les events depuis le staging? (que je puisse tester directement en staging, je crois pas pouvoir en dev)


