### PR TITLE
Update hub-eau.md

### DIFF
--- a/_data/producteurs/hub-eau.md
+++ b/_data/producteurs/hub-eau.md
@@ -7,7 +7,7 @@ short: Simplifier l'accès aux données sur l'eau.
 description: |
   Hub'Eau met à disposition des API qui permettent l’accès aux données du Système d'Information sur l'Eau (SIE) dans des formats propices à la réutilisation (CSV, JSON, GeoJSON).
   C'est le portail d'API de [Eau France](/producteurs/eaufrance)
-contact: https://assistance.brgm.fr/formulaire/posez-votre-question?tools=HubEau
-siteOpenData: https://quadrige.eaufrance.fr/Acces-aux-donnees
-siteAPI: https://hubeau.eaufrance.fr/page/apis
+contact: https://assistance.brgm.fr/aide/HubEau
+siteOpenData: https://data.eaufrance.fr/
+siteAPI: https://hubeau.eaufrance.fr/
 ---


### PR DESCRIPTION
modification des url du site contact, du site opendata (qui pointait vers Ifremer) et du site API.

- Détails (ignorer si ajout de contenu):
  - Modification de 3 URLs qui ne pointaient pas vers les bons services