### PR TITLE
fix: Ademe APIs documention links

### DIFF
--- a/_data/api/api_agribalyse.md
+++ b/_data/api/api_agribalyse.md
@@ -17,7 +17,7 @@ rate_limiting_resume: 10 appels / seconde / IP
 themes:
   - Environnement
 contact_link: https://www.ademe.fr/content/contacter
-doc_tech_link: https://koumoul.com/s/data-fair/api/v1/datasets/agribalyse-synthese/api-docs.json
+doc_tech_link: https://data.ademe.fr/data-fair/api/v1/datasets/agribalyse-synthese/api-docs.json
 doc_tech_external: https://data.ademe.fr/datasets/agribalyse-synthese
 datagouv_uuid:
   - 5f71f6b9f23df7fcd508af57

--- a/_data/api/api_aides_financieres_ademe.md
+++ b/_data/api/api_aides_financieres_ademe.md
@@ -18,7 +18,7 @@ rate_limiting_resume: 10 appels / seconde / IP
 themes:
   - Environnement
 contact_link: https://www.ademe.fr/content/contacter
-doc_tech_link: https://koumoul.com/s/data-fair/api/v1/datasets/les-aides-financieres-de-l'ademe/api-docs.json
+doc_tech_link: https://data.ademe.fr/data-fair/api/v1/datasets/les-aides-financieres-de-l'ademe/api-docs.json
 doc_tech_external: https://data.ademe.fr/datasets/les-aides-financieres-de-l'ademe
 datagouv_uuid:
   - 5f081465a1409f219b08f0f7

--- a/_data/api/api_aides_renovation_energetique.md
+++ b/_data/api/api_aides_renovation_energetique.md
@@ -18,7 +18,7 @@ rate_limiting_resume: 10 appels / seconde / IP
 themes:
   - Environnement
 contact_link: https://www.ademe.fr/content/contacter
-doc_tech_link: https://koumoul.com/s/data-fair/api/v1/datasets/simul'aideuros-dispositifs/api-docs.json
+doc_tech_link: https://data.ademe.fr/data-fair/api/v1/datasets/simul'aideuros-dispositifs/api-docs.json
 doc_tech_external: https://data.ademe.fr/datasets/simul'aideuros-dispositifs
 datagouv_uuid:
   - 5fcf368c7b470cf97746c4c1
@@ -42,7 +42,7 @@ L'API Aides financières à la rénovation énergetique permet d'interroger la l
 
 L’outil, proposé dans la France entière, y compris l’outremer, est encore en cours de déploiement en Bourgogne-Franche Comté, Aura et Pays de Loire ce qui explique une « sous-représentation » de certaines régions dans la base de données mise à disposition. Il est disponible sous forme d'IFRAME (contact : <a href='mailto:simulaides@ademe.fr'>simulaides@ademe.fr</a>)
 
-Cette liste est accompagnée [d'un lexique des données Simul'Aid€s](https://koumoul.com/s/data-fair/api/v1/datasets/simul'aideuros-dispositifs/metadata-attachments/Simulaide_lexique_donn%C3%A9es.pdf) afin d’en faciliter la compréhension.
+Cette liste est accompagnée [d'un lexique des données Simul'Aid€s](https://data.ademe.fr/data-fair/api/v1/datasets/simul'aideuros-dispositifs/metadata-attachments/Simulaide_lexique_donn%C3%A9es.pdf) afin d’en faciliter la compréhension.
 
 Vous pouvez également consulter la [la moyenne des coûts de travaux](https://data.ademe.fr/datasets/simul'aideuros-cout-des-travaux), saisis par les ménages.
 

--- a/_data/api/api_base_carbone.md
+++ b/_data/api/api_base_carbone.md
@@ -15,7 +15,7 @@ rate_limiting_resume: 10 appels / seconde / IP
 themes:
   - Environnement
 contact_link: https://www.ademe.fr/content/contacter
-doc_tech_link: https://koumoul.com/s/data-fair/api/v1/datasets/base-carbone(r)/api-docs.json
+doc_tech_link: https://data.ademe.fr/data-fair/api/v1/datasets/base-carbone(r)/api-docs.json
 doc_tech_external: https://data.ademe.fr/datasets/base-carbone(r)
 datagouv_uuid:
   - 5f5605e63ee74d0034395703

--- a/_data/api/api_dpe_batiments_publics.md
+++ b/_data/api/api_dpe_batiments_publics.md
@@ -17,7 +17,7 @@ rate_limiting_resume: 10 appels / seconde / IP
 themes:
   - Environnement
 contact_link: https://www.ademe.fr/content/contacter
-doc_tech_link: https://koumoul.com/s/data-fair/api/v1/datasets/dpe-tertiaire/api-docs.json
+doc_tech_link: https://data.ademe.fr/data-fair/api/v1/datasets/dpe-tertiaire/api-docs.json
 doc_tech_external: https://data.ademe.fr/datasets/dpe-tertiaire
 datagouv_uuid:
   - 6061abe367b3cc046a5a7e13

--- a/_data/api/api_dpe_logements.md
+++ b/_data/api/api_dpe_logements.md
@@ -15,7 +15,7 @@ rate_limiting_resume: 10 appels / seconde / IP
 themes:
   - Environnement
 contact_link: https://www.ademe.fr/content/contacter
-doc_tech_link: https://koumoul.com/s/data-fair/api/v1/datasets/dpe-france/api-docs.json
+doc_tech_link: https://data.ademe.fr/data-fair/api/v1/datasets/dpe-france/api-docs.json
 doc_tech_external: https://data.ademe.fr/datasets/dpe-france
 datagouv_uuid:
   - 5ee2391763c79811ddfbc86a


### PR DESCRIPTION
- Modification du code (technique)
- Détails :
  - Changement de l'URL de récupération de la description OpenAPI.
  - Une erreur CORS était remontées au niveau de la page affichant la documentation .
