### PR TITLE
Add stats module

### DIFF
--- a/_data/api/api-la-bonne-alternance.md
+++ b/_data/api/api-la-bonne-alternance.md
@@ -21,6 +21,10 @@ themes:
 rate_limiting_resume: de 5  à 20 appels / seconde
 rate_limiting_description: |
   Les quotas diffèrent en fonction des routes
+stats_detail_resume: de 5  à 20 appels / seconde
+stats_detail_description: |
+  Les quotas diffèrent en fonction des routes
+stats_detail_link: http://apple.com
 uptime: 98.82
 monitoring_link: https://mission-apprentissage.github.io/upptime/history/la-bonne-alternance-api
 last_update: 14/12/2020

--- a/_data/api/api-la-bonne-alternance.md
+++ b/_data/api/api-la-bonne-alternance.md
@@ -21,10 +21,10 @@ themes:
 rate_limiting_resume: de 5  à 20 appels / seconde
 rate_limiting_description: |
   Les quotas diffèrent en fonction des routes
-stats_detail_resume: de 5  à 20 appels / seconde
+stats_detail_resume: Test
 stats_detail_description: |
-  Les quotas diffèrent en fonction des routes
-stats_detail_link: http://apple.com
+  Test
+stats_detail_link: http://labonnealternance.apprentissage.beta.gouv.fr/metabase/public/dashboard/ce3c7892-0931-46a6-85c5-c768716aff04
 uptime: 98.82
 monitoring_link: https://mission-apprentissage.github.io/upptime/history/la-bonne-alternance-api
 last_update: 14/12/2020

--- a/components/api/apiDetails.tsx
+++ b/components/api/apiDetails.tsx
@@ -5,11 +5,18 @@ import constants from '../../constants';
 import { ButtonLink } from '../../uiComponents';
 import Speedometer from '../../uiComponents/icon/speedometer';
 import Cardiogram from '../../uiComponents/icon/cardiogram';
+import Stats from '../../uiComponents/icon/stats';
 
 interface IPropsRateLimiting {
   rate_limiting?: string;
   rate_limiting_resume?: string;
   rate_limiting_link?: string
+}
+
+interface IPropsStatsDetail {
+  stats_detail?: string;
+  stats_detail_resume?: string;
+  stats_detail_link?: string
 }
 
 interface IPropsMonitoring {
@@ -24,6 +31,7 @@ interface IPropsIsFranceConnected {
 
 interface IPropsDetails
   extends IPropsRateLimiting,
+    IPropsStatsDetail,
     IPropsMonitoring,
     IPropsIsFranceConnected {}
 
@@ -175,6 +183,54 @@ const RateLimitingDetail: React.FC<IPropsRateLimiting> = ({
   );
 };
 
+const StatsDetail: React.FC<IPropsStatsDetail> = ({
+  stats_detail,
+  stats_detail_resume,
+  stats_detail_link
+}) => {
+  const [showStatsDetailDesc, setShowStatsDetailDesc] = useState(false);
+  const toggle = () => setShowStatsDetailDesc(!showStatsDetailDesc);
+  const toggleKey = triggerOnEnterKey(toggle);
+  return (
+    <>
+      <div
+        className="badge  cursor-pointer"
+        onClick={toggle}
+        onKeyDown={toggleKey}
+        role="button"
+        tabIndex={0}
+      >
+        <div>{Speedometer}</div>
+        <div>
+          {stats_detail_resume
+            ? `Stats : ${stats_detail_resume}`
+            : 'Les statistiques d‘utilisation de cette API ne sont pas communiquées'}
+        </div>
+        {stats_detail && <ShowMore isOpen={showStatsDetailDesc} />}
+      </div>
+      {stats_detail && showStatsDetailDesc && (
+        <div className="details">
+          <i>{stats_detail}</i>
+          { stats_detail_link &&
+            <>
+              <div className="layout-right vertical-margin">
+                <ButtonLink
+                  href={stats_detail_link}
+                  target="_blank"
+                  rel="noopener"
+                  alt
+                >
+                  En savoir plus
+                </ButtonLink>
+              </div>
+            </>
+          }
+        </div>
+      )}
+    </>
+  );
+};
+
 const IsFranceConnectedDetail: React.FC<IPropsIsFranceConnected> = ({
   is_france_connected,
 }) => {
@@ -231,6 +287,9 @@ const ApiDetails: React.FC<IPropsDetails> = ({
   rate_limiting,
   rate_limiting_resume,
   rate_limiting_link,
+  stats_detail,
+  stats_detail_resume,
+  stats_detail_link,
   is_france_connected = null,
 }) => {
   return (
@@ -244,6 +303,11 @@ const ApiDetails: React.FC<IPropsDetails> = ({
         rate_limiting={rate_limiting}
         rate_limiting_resume={rate_limiting_resume}
         rate_limiting_link={rate_limiting_link}
+      />
+      <StatsDetail
+        stats_detail={stats_detail}
+        stats_detail_resume={stats_detail_resume}
+        stats_detail_link={stats_detail_link}
       />
       {(is_france_connected === 1 || is_france_connected === 2) && (
         <IsFranceConnectedDetail is_france_connected={is_france_connected} />

--- a/model/index.ts
+++ b/model/index.ts
@@ -135,6 +135,9 @@ export interface IApi extends IApiShort {
   rate_limiting_description: string;
   rate_limiting_resume: string;
   rate_limiting_link: string;
+  stats_detail: string;
+  stats_detail_resume: string;
+  stats_detail_link: string;
   partners: { slug?: string; name: string }[];
   themes: string[];
   keywords: string[];

--- a/model/index.ts
+++ b/model/index.ts
@@ -135,7 +135,7 @@ export interface IApi extends IApiShort {
   rate_limiting_description: string;
   rate_limiting_resume: string;
   rate_limiting_link: string;
-  stats_detail: string;
+  stats_detail_description: string;
   stats_detail_resume: string;
   stats_detail_link: string;
   partners: { slug?: string; name: string }[];

--- a/pages/les-api/[slug].tsx
+++ b/pages/les-api/[slug].tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { GetStaticProps, GetStaticPaths } from 'next';
-import { logParcoursClient } from '../../utils/client/analytics';
 
 import {
   getAPI,
@@ -56,6 +55,9 @@ const API: React.FC<IProps> = ({ api, guides, datagouvDatasets }) => {
     rate_limiting_description,
     rate_limiting_resume,
     rate_limiting_link,
+    stats_detail_description,
+    stats_detail_resume,
+    stats_detail_link,
     body,
     is_open,
     partners,
@@ -122,6 +124,9 @@ const API: React.FC<IProps> = ({ api, guides, datagouvDatasets }) => {
               rate_limiting={rate_limiting_description}
               rate_limiting_resume={rate_limiting_resume}
               rate_limiting_link={rate_limiting_link}
+              stats_detail={stats_detail_description}
+              stats_detail_resume={stats_detail_resume}
+              stats_detail_link={stats_detail_link}
               uptime={uptime}
               is_france_connected={is_france_connected}
             />

--- a/uiComponents/icon/stats.tsx
+++ b/uiComponents/icon/stats.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const Stats = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+  >
+    <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline>
+  </svg>
+);
+export default Stats;


### PR DESCRIPTION
When API call stats are shared and made public by the data producer, the API page displays a link to the monitoring on the right details pannel
