### PR TITLE
[API Entreprise] Parcours éditeur

### DIFF
--- a/components/questionTree/data/api-entreprise/administrations.ts
+++ b/components/questionTree/data/api-entreprise/administrations.ts
@@ -14,7 +14,7 @@ export const pathDevelopForAdministration = {
               <br/>
               <span role='img' aria-label='émoji avertissement'>⚠️</span> En tant que prestataire technique d’une entité administrative, vous pourrez être destinataire des informations techniques permettant l’usage de l’API mais en aucun cas des données elles-même.
               <br/>
-              <span role='img' aria-label='émoji information'>ℹ️</span>**Pour que votre demande soit traitée plus rapidement :** Au niveau de la section _Les modèles pré-remplis_, le modèle "_Demande spécifique aux éditeurs de logiciels_" est selectionné. Il est impératif de garder ce modèle et de ne pas en changer.
+              <span role='img' aria-label='émoji information'>ℹ️</span>**Pour que votre demande soit traitée plus rapidement :** Au niveau de la section _Les modèles pré-remplis_, le modèle "_Demande spécifique aux éditeurs de logiciels_" est sélectionné. Il est impératif de garder ce modèle et de ne pas en changer.
               <br/>
               <Button href='https://datapass.api.gouv.fr/api-entreprise?demarche=editeur' alt>Déposer une demande pour intégrer l'API Entreprise</Button>`,
           },

--- a/components/questionTree/data/api-entreprise/administrations.ts
+++ b/components/questionTree/data/api-entreprise/administrations.ts
@@ -11,7 +11,10 @@ export const pathDevelopForAdministration = {
               'Un **logiciel métier clé en main**, proposé à de nombreuses entités administratives',
             ],
             answer: `**Vous êtes éligible pour mettre à disposition de vos utilisateurs l’API Entreprise <span role='img' aria-label='émoji ok'>👍</span>**
-              <span role='img' aria-label='émoji avertissement'>⚠️</span> en tant que prestataire technique d’une entité administrative, vous pourrez être destinataire des informations techniques permettant l’usage de l’API mais en aucun cas des données elles-même.
+              <br/>
+              <span role='img' aria-label='émoji avertissement'>⚠️</span> En tant que prestataire technique d’une entité administrative, vous pourrez être destinataire des informations techniques permettant l’usage de l’API mais en aucun cas des données elles-même.
+              <br/>
+              <span role='img' aria-label='émoji information'>ℹ️</span>**Pour que votre demande soit traitée plus rapidement :** Au niveau de la section _Les modèles pré-remplis_, le modèle "_Demande spécifique aux éditeurs de logiciels_" est selectionné. Il est impératif de garder ce modèle et de ne pas en changer.
               <br/>
               <Button href='https://datapass.api.gouv.fr/api-entreprise?demarche=editeur' alt>Déposer une demande pour intégrer l'API Entreprise</Button>`,
           },


### PR DESCRIPTION
Ajout de contenu.
Pour éviter que les éditeurs change de modèle par défaut et en attendant que ce soit plus simple dans Datapass, ajout d'une phrase d'alerte.