### PR TITLE
fix: remove dependance on data.gouv.fr api

### DIFF
--- a/components/api/apiOpenDataSources.tsx
+++ b/components/api/apiOpenDataSources.tsx
@@ -23,24 +23,32 @@ export const fetchDatagouvDatasets = async (
 
   return await Promise.all(
     uuids.map(async uuid => {
-      const response = await fetch(
-        `https://www.data.gouv.fr/api/1/datasets/${uuid}`
-      );
-      const data = await response.json();
-      if (!response.ok) {
-        console.log(`----ERROR----`);
-        console.log(`Incorrect response for dataset : ${uuid}`);
-        console.log(`STATUS CODE : ${response.status}`);
-        console.log(`BODY : ${JSON.stringify(data)}`);
+      try {
+        const response = await fetch(
+          `https://www.data.gouv.fr/api/1/datasets/${uuid}`
+        );
+        const data = await response.json();
+        if (!response.ok) {
+          console.log(`----ERROR----`);
+          console.log(`Incorrect response for dataset : ${uuid}`);
+          console.log(`STATUS CODE : ${response.status}`);
+          console.log(`BODY : ${JSON.stringify(data)}`);
 
-        throw new Error(`Corrupted dataset uuid : ${uuid}`);
+          throw new Error(`Corrupted dataset uuid : ${uuid}`);
+        }
+
+        return {
+          title: data.title,
+          uuid,
+          organization: data.organization.name,
+        };
+      } catch {
+        return {
+          title: 'Jeu de donnée sur data.gouv.fr',
+          uuid,
+          organization: null,
+        };
       }
-
-      return {
-        title: data.title,
-        uuid,
-        organization: data.organization.name,
-      };
     })
   );
 };


### PR DESCRIPTION
closes #1143 

Encapsulate data.gouv.fr call into a try {...} catch {...}

Whats good : datagouv API response can no longer breaks build

Whaats not so good : datagouv broken links are no longer reported 