### PR TITLE
Api 1455 api parteprise arbre decision

### DIFF
--- a/_data/api/api-entreprise.md
+++ b/_data/api/api-entreprise.md
@@ -20,7 +20,11 @@ access_page:
 
       Pour vérifier que l’API Entreprise vous permet d’accéder aux données dont vous avez besoin, consultez nos différents <External href="https://entreprise.api.gouv.fr/cas_usages">cas d'usages</External> (marchés publics, aides et subventions, portail GRU ...) et le <External href="https://entreprise.api.gouv.fr/catalogue">catalogue des API</External>.
 
-      Conformément aux dispositions de <External href="https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000031366350&idArticle=LEGIARTI000031367412&dateTexte=&categorieLien=cid">l'article L114-8 du *code des relations entre le public et l'administration</External> vous ne pourrez accéder qu'aux seules informations ou données strictement nécessaires pour traiter une démarche de l'entreprise ou association concernée.
+      <p style="margin-left: 1rem; margin-right: 1rem;font-size: 0.9rem; line-height: 1.5rem;">Conformément aux dispositions de <External href="https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000031366350&idArticle=LEGIARTI000031367412&dateTexte=&categorieLien=cid">l'article L114-8 du Code des relations entre le public et l'administration</External> vous ne pourrez accéder qu'aux seules informations ou données strictement nécessaires pour traiter une démarche de l'entreprise ou association concernée.</p>
+
+
+      <NextSteps />
+      <p style="margin-top: 0rem; font-size: 0.9rem; line-height: 1.5rem;"> <External href="https://entreprise.api.gouv.fr/faq#api_entreprise_faq_entry_quelles-informations-me-seront-demandees">En savoir plus sur les informations demandées</External></p>
 
       <QuestionTree tree='api-entreprise' question='administrations' />
   - who:

--- a/_data/api/api-entreprise.md
+++ b/_data/api/api-entreprise.md
@@ -9,16 +9,18 @@ access_page:
       - Un particulier
     is_eligible: -1
     description: |
-      L’usage des données de l’API Entreprise est reservé aux acteurs publics : les administrations, leurs opérateurs et les collectivités, les acteurs de santé, etc.
+      L’usage de l’API Entreprise est **uniquement reservé aux acteurs publics** : les administrations, les collectivités, leurs opérateurs, les acteurs de santé, etc.
 
       <Button href='/les-api/api-entreprise#alternatives-en-acces-libre' >Consulter les alternatives</Button>
   - who:
-      - Une entité administrative
+      - Une collectivité ou une administration
     is_eligible: 1
     description: |
       L’API Entreprise vous permet d’accéder directement aux données administratives des entreprises et des associations pour faciliter leurs démarches (demandes d’aides, marchés publics, ...).
 
-      Pour vérifier que l’API Entreprise vous permet d’accéder aux données dont vous avez besoin, consultez nos différents [cas d'usages](https://entreprise.api.gouv.fr/cas_usages) (marchés publics, aides et subventions, portail GRU ...) et le [catalogue des API](https://entreprise.api.gouv.fr/catalogue).
+      Pour vérifier que l’API Entreprise vous permet d’accéder aux données dont vous avez besoin, consultez nos différents <External href="https://entreprise.api.gouv.fr/cas_usages">cas d'usages</External> (marchés publics, aides et subventions, portail GRU ...) et le <External href="https://entreprise.api.gouv.fr/catalogue">catalogue des API</External>.
+
+      Conformément aux dispositions de <External href="https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000031366350&idArticle=LEGIARTI000031367412&dateTexte=&categorieLien=cid">l'article L114-8 du *code des relations entre le public et l'administration</External> vous ne pourrez accéder qu'aux seules informations ou données strictement nécessaires pour traiter une démarche de l'entreprise ou association concernée.
 
       <QuestionTree tree='api-entreprise' question='administrations' />
   - who:

--- a/_data/api/api-particulier.md
+++ b/_data/api/api-particulier.md
@@ -5,7 +5,7 @@ is_open: -1 # -1 means API not open
 datapass_link: https://datapass.api.gouv.fr/api-particulier
 access_page:
   - who:
-      - Un particulier ou une entreprise
+      - Un particulier
     is_eligible: -1
     description: |
       L’usage de l’API Particulier est **uniquement reservé aux acteurs publics** : les administrations, les collectivités, leurs opérateurs, les acteurs de santé, etc.
@@ -15,11 +15,10 @@ access_page:
       - Une collectivité ou une administration
     is_eligible: 1
     description: |
-      L’API Particulier vous permet d’accéder directement aux données administratives des particuliers pour faciliter leurs démarches (cantines, titres de transport, aides sociales, démarches famille, etc...).
-
+      L’API Particulier vous permet d’accéder directement aux données administratives des particuliers pour faciliter leurs démarches (cantines, titres de transport, aides sociales, démarches famille, etc...).<br/>
       Pour vérifier que l’API Particulier vous permet d’accéder aux données dont vous avez besoin, consultez le <External href="https://particulier.api.gouv.fr/catalogue">catalogue des API</External> et nos différents <External href="https://api.gouv.fr/les-api/api-particulier#exemples-d%E2%80%99application">cas d'usages</External>.
 
-      Conformément aux dispositions de <External href="https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000031366350&idArticle=LEGIARTI000031367412&dateTexte=&categorieLien=cid">l'article L114-8 du *code des relations entre le public et l'administration</External> vous ne pourrez accéder qu'aux seules informations ou données strictement nécessaires pour traiter une démarche du particulier concerné.
+      <p style="margin-left: 1rem; margin-right: 1rem;font-size: 0.9rem; line-height: 1.5rem;">Conformément aux dispositions de <External href="https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000031366350&idArticle=LEGIARTI000031367412&dateTexte=&categorieLien=cid">l'article L114-8 du Code des relations entre le public et l'administration</External> vous ne pourrez accéder qu'aux seules informations ou données strictement nécessaires pour traiter une démarche du particulier concerné.</p>
 
       <NextSteps />
       <QuestionTree tree='api-particulier' question='apipart'/>
@@ -29,19 +28,18 @@ access_page:
     description: |
       L’usage de l’API Particulier est **uniquement reservé aux acteurs publics** : les administrations, les collectivités, leurs opérateurs, les acteurs de santé, etc.
 
-      Si vous êtes **éditeur de logiciels, c'est à votre collectivité ou administration de faire sa demande d'habilitation.**
-
-      En revanche, vous pouvez nous demander de vous référencer sur un cas d'usage afin de proposer des formulaires pré-remplis et ainsi simplifier l'expérience de vos clients publics.
-
-      <Button href="https://form.typeform.com/to/GU90FCIE">Demander à être référencé</Button>
 
       <Button href="/rechercher-api">Rechercher une autre API</Button>
+
+      Si vous êtes **éditeur de logiciels pour des acteurs publics, c'est à vos utilisateurs collectivité ou administration de faire une demande d'habilitation.** En revanche, vous pouvez nous demander de vous référencer sur un cas d'usage afin de proposer des formulaires pré-remplis et ainsi simplifier l'expérience de vos clients publics.
+      <External href="https://form.typeform.com/to/GU90FCIE">Demander à être référencé</External>
+
   - who:
       - Un éditeur de logiciel
     is_eligible: -1
     description: |
-      Si vous êtes **éditeur de logiciels, c'est à votre collectivité ou administration de faire sa demande d'habilitation.**
-
+      Si vous êtes **éditeur de logiciels pour des acteurs publics, c'est à vos utilisateurs collectivité ou administration de faire une demande d'habilitation.** 
+      
       En revanche, vous pouvez nous demander de vous référencer sur un cas d'usage afin de proposer des formulaires pré-remplis et ainsi simplifier l'expérience de vos clients publics.
 
       <Button href="https://form.typeform.com/to/GU90FCIE">Demander à être référencé</Button>

--- a/_data/api/api-particulier.md
+++ b/_data/api/api-particulier.md
@@ -48,6 +48,7 @@ access_page:
 
       Pour toute autre demande, consultez notre page <External href="https://particulier.api.gouv.fr/faq">FAQ & contact</External>.
       
+stat:
   lastXdays: 30
   url: https://particulier.api.gouv.fr/stats
   label: justificatifs papier évités

--- a/_data/api/api-particulier.md
+++ b/_data/api/api-particulier.md
@@ -8,20 +8,34 @@ access_page:
       - Un particulier ou une entreprise
     is_eligible: -1
     description: |
-      Seules les administrations sont habilitées à utiliser API Particulier.
+      L’usage de l’API Particulier est **uniquement reservé aux acteurs publics** : les administrations, les collectivités, leurs opérateurs, les acteurs de santé, etc.
 
       <Button href="/rechercher-api">Rechercher une autre API</Button>
   - who:
       - Une collectivité ou une administration
     is_eligible: 1
     description: |
-      Conformément aux dispositions de <External href="https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000031366350&idArticle=LEGIARTI000031367412&dateTexte=&categorieLien=cid">l'article L114-8</External> du *code des relations entre le public et l'administration*, seules les administrations sont habilitées à échanger entre elles des informations ou données strictement nécessaires pour traiter une démarche.
+      L’API Particulier vous permet d’accéder directement aux données administratives des particuliers pour faciliter leurs démarches (cantines, titres de transport, aides sociales, démarches famille, etc...).
 
-      Pour obtenir un agrément, vous devez **justifier d'une simplification pour les citoyens**, et vous engager à
-      n'accéder aux données personnelles qu'avec **l'accord explicite** de l'usager.
+      Pour vérifier que l’API Particulier vous permet d’accéder aux données dont vous avez besoin, consultez le <External href="https://particulier.api.gouv.fr/catalogue">catalogue des API</External> et nos différents <External href="https://api.gouv.fr/les-api/api-particulier#exemples-d%E2%80%99application">cas d'usages</External>.
+
+      Conformément aux dispositions de <External href="https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000031366350&idArticle=LEGIARTI000031367412&dateTexte=&categorieLien=cid">l'article L114-8 du *code des relations entre le public et l'administration</External> vous ne pourrez accéder qu'aux seules informations ou données strictement nécessaires pour traiter une démarche du particulier concerné.
 
       <NextSteps />
       <QuestionTree tree='api-particulier' question='apipart'/>
+  - who:
+      - Une entreprise ou une association
+    is_eligible: -1
+    description: |
+      L’usage de l’API Particulier est **uniquement reservé aux acteurs publics** : les administrations, les collectivités, leurs opérateurs, les acteurs de santé, etc.
+
+      Si vous êtes **éditeur de logiciels, c'est à votre collectivité ou administration de faire sa demande d'habilitation.**
+
+      En revanche, vous pouvez nous demander de vous référencer sur un cas d'usage afin de proposer des formulaires pré-remplis et ainsi simplifier l'expérience de vos clients publics.
+
+      <Button href="https://form.typeform.com/to/GU90FCIE">Demander à être référencé</Button>
+
+      <Button href="/rechercher-api">Rechercher une autre API</Button>
   - who:
       - Un éditeur de logiciel
     is_eligible: -1

--- a/_data/api/api-particulier.md
+++ b/_data/api/api-particulier.md
@@ -42,10 +42,12 @@ access_page:
     description: |
       Si vous êtes **éditeur de logiciels pour des acteurs publics, c'est à vos utilisateurs collectivité ou administration de faire une demande d'habilitation.** 
       
-      En revanche, vous pouvez nous demander de vous référencer sur un cas d'usage afin de proposer des formulaires pré-remplis et ainsi simplifier l'expérience de vos clients publics.
+      En revanche, vous pouvez nous demander de vous référencer sur un cas d'usage afin de proposer des formulaires pré-remplis et ainsi simplifier l'expérience de vos clients publics : 
 
       <Button href="https://form.typeform.com/to/GU90FCIE">Demander à être référencé</Button>
-stat:
+
+      Pour toute autre demande, consultez notre page <External href="https://particulier.api.gouv.fr/faq">FAQ & contact</External>.
+      
   lastXdays: 30
   url: https://particulier.api.gouv.fr/stats
   label: justificatifs papier évités

--- a/_data/api/api-particulier.md
+++ b/_data/api/api-particulier.md
@@ -21,6 +21,8 @@ access_page:
       <p style="margin-left: 1rem; margin-right: 1rem;font-size: 0.9rem; line-height: 1.5rem;">Conformément aux dispositions de <External href="https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000031366350&idArticle=LEGIARTI000031367412&dateTexte=&categorieLien=cid">l'article L114-8 du Code des relations entre le public et l'administration</External> vous ne pourrez accéder qu'aux seules informations ou données strictement nécessaires pour traiter une démarche du particulier concerné.</p>
 
       <NextSteps />
+      <p style="margin-top: 0rem; font-size: 0.9rem; line-height: 1.5rem;"> <External href="https://particulier.api.gouv.fr/faq#quelles-informations-me-seront-demandees">En savoir plus sur les informations demandées</External></p>
+
       <QuestionTree tree='api-particulier' question='apipart'/>
   - who:
       - Une entreprise ou une association

--- a/components/questionTree/data/api-entreprise/administrations.ts
+++ b/components/questionTree/data/api-entreprise/administrations.ts
@@ -3,35 +3,20 @@ export const pathDevelopForAdministration = {
   choiceTree: [
     {
       choices: ['Aux administrations et/ou aux collectivités'],
-      next: {
-        question: 'Quel type de service proposez-vous aux administrations ?',
-        choiceTree: [
-          {
-            choices: [
-              'Un **logiciel métier clé en main**, proposé à de nombreuses entités administratives',
-            ],
-            answer: `**Vous êtes éligible pour mettre à disposition de vos utilisateurs l’API Entreprise <span role='img' aria-label='émoji ok'>👍</span>**
-              <br/>
-              <span role='img' aria-label='émoji avertissement'>⚠️</span> En tant que prestataire technique d’une entité administrative, vous pourrez être destinataire des informations techniques permettant l’usage de l’API mais en aucun cas des données elles-même.
-              <br/>
-              <span role='img' aria-label='émoji information'>ℹ️</span>**Pour que votre demande soit traitée plus rapidement :** Au niveau de la section _Les modèles pré-remplis_, le modèle "_Demande spécifique aux éditeurs de logiciels_" est sélectionné. Il est impératif de garder ce modèle et de ne pas en changer.
-              <br/>
-              <Button href='https://datapass.api.gouv.fr/api-entreprise?demarche=editeur' alt>Déposer une demande pour intégrer l'API Entreprise</Button>`,
-          },
-          {
-            choices: [
-              'Un logiciel conçu **sur mesure** pour une administration',
-            ],
-            answer: `**L’administration pour laquelle vous proposez une prestation est éligible à l’API&nbsp;Entreprise <span role='img' aria-label='émoji ok'>👍</span>**
-            <br/>
-            **C’est à elle de compléter une demande auprès d’API Entreprise.** Elle devra dans sa demande d’habilitation vous renseigner en tant que “contact technique”. Le lien ci-dessous permet à l’administration d’accéder à la demande d’habilitation, partagez-lui :
-            <br/>
-            <External href='/les-api/api-entreprise/demande-acces'>Lien vers la page</External>
-            &nbsp;
-            <ButtonCopy source='https://api.gouv.fr/les-api/api-entreprise/demande-acces'/>`,
-          },
-        ],
-      },
+      answer: `**Vous êtes éligible pour mettre à disposition de vos utilisateurs l’API Entreprise <span role='img' aria-label='émoji ok'>👍</span>**
+          <br/>
+          <span role='img' aria-label='émoji avertissement'>⚠️</span> En tant que prestataire technique d’une entité administrative, vous pourrez être destinataire des informations techniques permettant l’usage de l’API mais en aucun cas des données elles-même.
+          <br/>
+          <span role='img' aria-label='émoji information'>ℹ️</span>** Pour que votre demande soit traitée plus rapidement :** Au niveau de la section "_Les modèles pré-remplis_", le modèle "_Demande spécifique aux éditeurs de logiciels_" est sélectionné. Il est impératif de garder ce modèle et de ne pas en changer.
+          <br/>
+          **Pour remplir votre demande, vous aurez notamment besoin de:**
+          <ul>
+            <li>votre numéro de SIRET ;</li>
+            <li>décrire votre activité ;</li>
+            <li>décrire les cas d'usage de l'API Entreprise qu'auront vos clients publics ;</li>
+            <li>justifier les API demandées.</li>
+          </ul>
+          <Button href='https://datapass.api.gouv.fr/api-entreprise?demarche=editeur' alt>Déposer une demande pour intégrer l'API Entreprise</Button>`,
     },
     {
       choices: ['Aux entreprises, associations et/ou particuliers'],

--- a/components/questionTree/data/api-entreprise/editeurs.ts
+++ b/components/questionTree/data/api-entreprise/editeurs.ts
@@ -1,0 +1,80 @@
+export const pathDevelopForEditors = {
+  question: "Sélectionnez l'éditeur et la solution qui vous concerne :",
+  choiceTree: [
+      {
+      choices: [
+          'E-Attestations - Conformité titulaires de marchés',
+      ],
+      answer: `<br/><<Button href="https://datapass.api.gouv.fr/api-entreprise?demarche=e_attestations">Remplir une demande</Button>
+      `,
+      },
+      {
+      choices: [
+          'Provigis - Conformité titulaires de marchés',
+      ],
+      answer: `<br/><Button href="https://datapass.api.gouv.fr/api-entreprise?demarche=provigis">Remplir une demande</Button>
+      `,
+      },
+      {
+      choices: [
+          'Achat Solution - Conformité titulaires de marchés',
+      ],
+      answer: `<br/><Button href="https://datapass.api.gouv.fr/api-entreprise?achat_solution>Remplir une demande</Button>
+      `,
+      },
+      {
+      choices: [
+           'Atexo - Dématérialisation des marchés publics',
+      ],
+      answer: `<br/><Button href="https://datapass.api.gouv.fr/api-entreprise?demarche=atexo">Remplir une demande</Button>
+      `,
+      },
+      {
+      choices: [
+          'MGDIS - Portail des aides',
+      ],
+      answer: `<br/><Button href="https://datapass.api.gouv.fr/api-entreprise?demarche=mgdis">Remplir une demande</Button>
+      `,
+      },
+      {
+      choices: [
+          'Setec/Atexo - Dématérialisation des marchés publics',
+      ],
+      answer: `<br/><Button href="https://datapass.api.gouv.fr/api-entreprise?demarche=setec">Remplir une demande</Button>
+      `,
+      },
+      {
+      choices: [
+          'Achatpublic - achatpublic.com',
+          'Actradis',
+          'Arnia - Pack commande publique',
+          'Atline Services - marches-securises.fr',
+          'AWS - AWS-achat',
+          'Axyus',
+          'Dematis - e-marchespublics.com',
+          'Entr\'ouvert - Publik',
+          'Klekoon - klekoon.com',
+          'Maximilien',
+          'Megalis Bretagne',
+          'PICTAV Informatique',
+          'SmartGlobal - Smart Global Governance',
+          'Solution Attestations',
+      ],
+      answer: `**Bonne nouvelle ! Vous êtes éligible et votre éditeur/profil acheteur a déjà intégré l’API Entreprise. <span role='img' aria-label='émoji ok'>👍</span>**
+      <br/><br/>
+      Vous n’avez plus qu’à vous adresser directement à votre éditeur.`,
+      },
+      {
+      choices: ['**Mon éditeur ou la solution recherchée ne figure pas dans cette liste**'],
+      answer: `**Vous êtes éligible mais votre éditeur/profil acheteur n’a pas intégré l’API&nbsp;Entreprise <span role="img" aria-label="émoji loupe">🔎</span>**
+      <br/>
+      Déposez une demande pour expliciter vos besoins et votre situation. L’équipe API Entreprise vous contactera pour identifier des pistes de solutions, et contactera le cas échéant votre éditeur (pensez donc bien à préciser le nom de votre éditeur et ses coordonnées).
+      <br/>
+      <Button href='https://datapass.api.gouv.fr/api-entreprise' target='_blank' rel="noreferrer noopener" alt>Déposer une demande</Button>
+      <br/>
+      **Nota :** L’API Entreprise s’utilise au travers d’un logiciel métier, votre éditeur vous met probablement à disposition un logiciel de ce type.
+      <br/>
+      En revanche, comme ce dernier n’a pas encore intégré l’API Entreprise, les instructeurs de l’API Entreprise devront, entre autres, vérifier si votre éditeur a les <External href='https://entreprise.api.gouv.fr/doc/#fondamentaux'>prérequis techniques</External> pour utiliser l’API Entreprise.`,
+    },
+  ],
+};

--- a/components/questionTree/data/api-entreprise/editeurs.ts
+++ b/components/questionTree/data/api-entreprise/editeurs.ts
@@ -61,7 +61,7 @@ export const pathDevelopForEditors = {
           'Solution Attestations',
       ],
       answer: `**Bonne nouvelle ! Vous êtes éligible et votre éditeur/profil acheteur a déjà intégré l’API Entreprise. <span role='img' aria-label='émoji ok'>👍</span>**
-      <br/><br/>
+      <br/>
       Vous n’avez plus qu’à vous adresser directement à votre éditeur.`,
       },
       {

--- a/components/questionTree/data/api-entreprise/editeurs.ts
+++ b/components/questionTree/data/api-entreprise/editeurs.ts
@@ -5,7 +5,7 @@ export const pathDevelopForEditors = {
       choices: [
           'E-Attestations - Conformité titulaires de marchés',
       ],
-      answer: `<br/><<Button href="https://datapass.api.gouv.fr/api-entreprise?demarche=e_attestations">Remplir une demande</Button>
+      answer: `<br/><Button href="https://datapass.api.gouv.fr/api-entreprise?demarche=e_attestations">Remplir une demande</Button>
       `,
       },
       {
@@ -19,7 +19,7 @@ export const pathDevelopForEditors = {
       choices: [
           'Achat Solution - Conformité titulaires de marchés',
       ],
-      answer: `<br/><Button href="https://datapass.api.gouv.fr/api-entreprise?achat_solution>Remplir une demande</Button>
+      answer: `<br/><Button href="https://datapass.api.gouv.fr/api-entreprise?demarche=achat_solution">Remplir une demande</Button>
       `,
       },
       {
@@ -65,7 +65,7 @@ export const pathDevelopForEditors = {
       Vous n’avez plus qu’à vous adresser directement à votre éditeur.`,
       },
       {
-      choices: ['**Mon éditeur ou la solution recherchée ne figure pas dans cette liste**'],
+      choices: ['**La solution de votre éditeur ne figure pas dans cette liste**'],
       answer: `**Vous êtes éligible mais votre éditeur/profil acheteur n’a pas intégré l’API&nbsp;Entreprise <span role="img" aria-label="émoji loupe">🔎</span>**
       <br/>
       Déposez une demande pour expliciter vos besoins et votre situation. L’équipe API Entreprise vous contactera pour identifier des pistes de solutions, et contactera le cas échéant votre éditeur (pensez donc bien à préciser le nom de votre éditeur et ses coordonnées).

--- a/components/questionTree/data/api-entreprise/eligible.ts
+++ b/components/questionTree/data/api-entreprise/eligible.ts
@@ -6,10 +6,17 @@ export const pathEligible = {
   choiceTree: [
     {
       choices: [
-        '**Nos développeurs internes.**<br/>Ils conçoivent une solution logicielle sur-mesure pour mon organisation.',
-        '**Nos développeurs prestataires.**<br/>Ils conçoivent une solution logicielle sur-mesure pour mon organisation.',
+        '**Vos développeurs internes.**<br/>Ils conçoivent une solution logicielle sur-mesure pour votre organisation.',
       ],
       answer: `**<span role='img' aria-label='émoji ok'>👍</span> Vous êtes éligible et avez les <External href='https://entreprise.api.gouv.fr/developpeurs#prerequis-techniques'>prérequis techniques</External> pour intégrer l’API Entreprise** à votre logiciel interne de traitement des démarches des associations et des entreprises.**
+      <br/><br/>
+      <Button href='https://datapass.api.gouv.fr/api-entreprise' target='_blank' rel="noreferrer noopener">Déposer une demande</Button>`,
+    },
+    {
+      choices: [
+        '**Vos développeurs prestataires.**<br/>Ils conçoivent une solution logicielle sur-mesure pour votre organisation.',
+      ],
+      answer: `**<span role='img' aria-label='émoji ok'>👍</span> Vous êtes éligible et vos développeurs externes ont les <External href='https://entreprise.api.gouv.fr/developpeurs#prerequis-techniques'>prérequis techniques</External> pour intégrer l’API Entreprise** à votre logiciel interne de traitement des démarches des associations et des entreprises.**
       <br/><br/>
       <Button href='https://datapass.api.gouv.fr/api-entreprise' target='_blank' rel="noreferrer noopener">Déposer une demande</Button>`,
     },
@@ -23,21 +30,26 @@ export const pathEligible = {
       choices: [
         '**Je n’ai ni équipe technique, ni éditeur.**<br/>Actuellement, je contacte les entreprises et associations une par une et traite leurs données à la main.',
       ],
-      answer: `** Vous êtes éligible mais n'avez pas les <External href='https://entreprise.api.gouv.fr/developpeurs#prerequis-techniques'>prérequis techniques</External> pour utiliser l’API&nbsp;Entreprise <span role='img' aria-label='émoji loupe'>🔎</span>**
+      answer: `** Vous êtes éligible mais n'avez pas les <External href='https://entreprise.api.gouv.fr/developpeurs#prerequis-techniques'>prérequis techniques</External> pour utiliser l’API&nbsp;Entreprise**
       <br/>
-      L’API Entreprise s’utilise au travers d’un logiciel métier, comme par exemple un profil acheteur pour les marchés publics. Si vous collectez et traitez les données à la main, vous n’avez probablement pas un logiciel dédié aux démarches.
+      <span role='img' aria-label='émoji loupe'>🔎</span>&nbsp;L’API Entreprise s’utilise au travers d’un logiciel métier, comme par exemple un profil acheteur pour les marchés publics. Si vous collectez et traitez les données à la main, vous n’avez probablement pas un logiciel dédié aux démarches.
       <br/>
+      <div style="margin: 2rem; padding: 1rem; background-color: #EEEEEE; border-right: gray; border: 20px">
+      <span role='img' aria-label='émoji cadeau'>🎁</span>**&nbsp;Nouveauté ! Faites partie des 1ers utilisateurs de « l'espace agent public » de l'annuaire des entreprises !**<br/> Vous devez vérifier les informations financières, fiscales et sociales des entreprises-associations ? Votre cadre juridique le permet ?
+      <br/><External href='https://form.typeform.com/to/ol1jlpdf'><span role='img' aria-label='émoji flèche'>➡️</span> C'est possible en 1 clic en remplissant ce questionnaire</External>
       <br/>
-      <span role='img' aria-label='émoji cadeau'>🎁</span>**Nouveauté ! Faites partie des 1ers utilisateurs de « l'espace agent public » de l'annuaire des entreprises !**.<br/> Vous devez vérifier les informations financières, fiscales et sociales des entreprises-associations ? Votre cadre juridique le permet ?
-      <br/>- <External href='https://form.typeform.com/to/ol1jlpdf'>C'est possible en 1 clic en remplissant ce questionnaire</External>
-      <br/>
-      <br/>
-      **Autrement, vous pouvez :<br/>** - **contacter des éditeurs de logiciel ayant déjà intégré l’API Entreprise :**
+      </div>
+      **Autrement, vous pouvez :**<br/>
+      <ul>
+      <li>**Contacter des éditeurs de logiciel ayant déjà intégré l’API Entreprise :**
       <br/><Button href='https://entreprise.api.gouv.fr/cas_usage/aides_publiques/#liste-d%C3%A9diteurs' target='_blank' rel="noreferrer noopener" alt>Liste des éditeurs Aides Publiques</Button>
-      <Button href='https://entreprise.api.gouv.fr/cas_usage/marches_publics/#liste-d%C3%A9diteurs' target='_blank' rel="noreferrer noopener" alt>Liste des éditeurs Marchés Publics</Button>
-      <br/>- **déposer une demande afin de nous expliquer votre contexte d’utilisation et vos besoins.** Les instructeurs d’API Entreprise étudieront votre demande. L’identification d’une équipe technique sera indispensable pour délivrer une habilitation. Merci de nous indiquer dans le formulaire que vous n'avez pas d'équipe technique pour accélerer le traitement de votre demande.
+      <Button href='https://entreprise.api.gouv.fr/cas_usage/marches_publics/#liste-d%C3%A9diteurs' target='_blank' rel="noreferrer noopener" alt>Liste des éditeurs Marchés Publics</Button></li>
       <br/>
-      <Button href='https://datapass.api.gouv.fr/api-entreprise' target='_blank' rel="noreferrer noopener" alt>Déposer une demande</Button>`,
+      <li>**déposer une demande afin de nous expliquer votre contexte d’utilisation et vos besoins.** Les instructeurs d’API Entreprise étudieront votre demande. L’identification d’une équipe technique sera indispensable pour délivrer une habilitation. Merci de nous indiquer dans le formulaire que vous n'avez pas d'équipe technique pour accélerer le traitement de votre demande.
+      <br/>
+      <Button href='https://datapass.api.gouv.fr/api-entreprise' target='_blank' rel="noreferrer noopener" alt>Déposer une demande</Button>
+      </li>
+      </ul>`,
     },
   ],
 };

--- a/components/questionTree/data/api-entreprise/eligible.ts
+++ b/components/questionTree/data/api-entreprise/eligible.ts
@@ -22,13 +22,13 @@ export const pathEligible = {
     },
     {
       choices: [
-        '**Mon éditeur.**<br/>Rien à coder, j’utilise une solution clé en main proposée par un éditeur.',
+        '**Votre éditeur.**<br/>Rien à coder, Vous utilisez une solution clé en main proposée par un éditeur.',
       ],
       next: pathDevelopForEditors
     },
     {
       choices: [
-        '**Je n’ai ni équipe technique, ni éditeur.**<br/>Actuellement, je contacte les entreprises et associations une par une et traite leurs données à la main.',
+        '**Ni équipe technique, ni éditeur.**<br/>Actuellement, vous contactez les entreprises et associations une par une et traitez leurs données à la main.',
       ],
       answer: `** Vous êtes éligible mais n'avez pas les <External href='https://entreprise.api.gouv.fr/developpeurs#prerequis-techniques'>prérequis techniques</External> pour utiliser l’API&nbsp;Entreprise**
       <br/>

--- a/components/questionTree/data/api-entreprise/eligible.ts
+++ b/components/questionTree/data/api-entreprise/eligible.ts
@@ -1,3 +1,5 @@
+import { pathDevelopForEditors } from './editeurs';
+
 export const pathEligible = {
   question:
     'Qui sera en charge techniquement de l’intégration de l’API Entreprise ?',
@@ -15,49 +17,7 @@ export const pathEligible = {
       choices: [
         '**Mon éditeur.**<br/>Rien à coder, j’utilise une solution clé en main proposée par un éditeur.',
       ],
-      next: {
-        question:
-          "Votre éditeur ou profil acheteur a-t-il déjà intégré l'API Entreprise ? Sélectionnez votre éditeur dans la liste ci-dessous :",
-        choiceTree: [
-          {
-            choices: [
-              'Achatpublic - achatpublic.com',
-              'Actradis',
-              'Arnia - Pack commande publique',
-              'Atexo - LocalTrust',
-              'Atline Services - marches-securises.fr',
-              'AWS - AWS-achat',
-              'Axyus',
-              'Dematis - e-marchespublics.com',
-              'E-attestations - E-attestations.com',
-              'Entr\'ouvert - Publik',
-              'Klekoon - klekoon.com',
-              'Maximilien',
-              'Megalis Bretagne',
-              'MGDIS - Portail des aides',
-              'PICTAV Informatique',
-              'Provigis - Provigis plateforme',
-              'SmartGlobal - Smart Global Governance',
-              'Solution Attestations',
-            ],
-            answer: `**Bonne nouvelle ! Vous êtes éligible et votre éditeur/profil acheteur a déjà intégré l’API Entreprise. <span role='img' aria-label='émoji ok'>👍</span>**
-            <br/><br/>
-            Vous n’avez plus qu’à vous adresser directement à votre éditeur.`,
-          },
-          {
-            choices: ['**Mon éditeur ne figure pas dans cette liste**'],
-            answer: `**Vous êtes éligible mais votre éditeur/profil acheteur n’a pas intégré l’API&nbsp;Entreprise <span role="img" aria-label="émoji loupe">🔎</span>**
-            <br/>
-            Déposez une demande pour expliciter vos besoins et votre situation. L’équipe API Entreprise vous contactera pour identifier des pistes de solutions, et contactera le cas échéant votre éditeur (pensez donc bien à préciser le nom de votre éditeur et ses coordonnées).
-            <br/>
-            <Button href='https://datapass.api.gouv.fr/api-entreprise' target='_blank' rel="noreferrer noopener" alt>Déposer une demande</Button>
-            <br/>
-            **Nota :** L’API Entreprise s’utilise au travers d’un logiciel métier, votre éditeur vous met probablement à disposition un logiciel de ce type.
-            <br/>
-            En revanche, comme ce dernier n’a pas encore intégré l’API Entreprise, les instructeurs de l’API Entreprise devront, entre autres, vérifier si votre éditeur a les <External href='https://entreprise.api.gouv.fr/doc/#fondamentaux'>prérequis techniques</External> pour utiliser l’API Entreprise.`,
-          },
-        ],
-      },
+      next: pathDevelopForEditors
     },
     {
       choices: [

--- a/components/questionTree/data/api-entreprise/index.ts
+++ b/components/questionTree/data/api-entreprise/index.ts
@@ -7,8 +7,13 @@ const apiEntrepriseQuestions = {
     choiceTree: [
       {
         choices: [
-          'dîte **“chargée d’une mission de service public”**',
-          'dîte **"délégataire de service public”**',
+          '**un prestataire d’une entité publique** pour développer des logiciels',
+        ],
+        next: pathDevelopForAdministration,
+      },
+      {
+        choices: [
+          'dite "**chargée d’une mission de service public**" ou "**délégataire de service public**"',
         ],
         answer: `**Vous êtes bien éligible <span role='img' aria-label='émoji oui'>👌</span> !**
         <br/>
@@ -17,12 +22,6 @@ const apiEntrepriseQuestions = {
         Pour vérifier que l’API Entreprise vous permet d’accéder aux données dont vous avez besoin, consultez : <br/> - le [catalogue des données](https://entreprise.api.gouv.fr/catalogue/) ; <br/> - les [cas d’usage](https://entreprise.api.gouv.fr/cas_usage/) de l’API Entreprise.
         `,
         next: pathEligible,
-      },
-      {
-        choices: [
-          '**prestataire d’une entité administrative** et développant des logiciels/interfaces',
-        ],
-        next: pathDevelopForAdministration,
       },
       {
         choices: [

--- a/components/questionTree/data/api-particulier/eligible.ts
+++ b/components/questionTree/data/api-particulier/eligible.ts
@@ -1,5 +1,5 @@
 export const pathEligible = {
-    question: 'Quel est l’éditeur de logiciel qui implémentera l’API ?',
+    question: "Quel est l’éditeur de logiciel qui implémentera l’API ?",
     choiceTree: [
         {
         choices: [
@@ -75,7 +75,7 @@ export const pathEligible = {
         choices: [
             'Technocarte',
         ],
-        answer: 
+        answer:
         `<br/><Button href="https://datapass.api.gouv.fr/api-particulier">Remplir une demande</Button>
         `,
         },
@@ -183,14 +183,18 @@ export const pathEligible = {
         ],
         answer: `<br/><Button href="https://datapass.api.gouv.fr/api-particulier">Remplir une demande</Button>
         `,
-        }, 
+        },
         {
-        choices: [
-            'Autre',
-        ],
-        answer: `<br/><Button href="https://datapass.api.gouv.fr/api-particulier">Remplir une demande</Button>
-        `,
-            }, 
+          choices: ['**Mon éditeur ne figure pas dans cette liste**'],
+          answer: `**Vous êtes éligible mais votre éditeur n’a pas intégré l’API&nbsp;Particulier <span role="img" aria-label="émoji loupe">🔎</span>**
+          <br/>
+          Déposez une demande pour expliciter vos besoins et votre situation. L’équipe API Particulier vous contactera pour identifier des pistes de solutions, et contactera le cas échéant votre éditeur (pensez donc bien à préciser le nom de votre éditeur et ses coordonnées).
+          <br/>
+          <Button href='https://datapass.api.gouv.fr/api-particulier' target='_blank' rel="noreferrer noopener" alt>Déposer une demande</Button>
+          <br/>
+          **Nota :** L’API Particulier s’utilise au travers d’un logiciel métier, votre éditeur vous met probablement à disposition un logiciel de ce type.
+          <br/>
+          En revanche, comme ce dernier n’a pas encore intégré l’API Particulier, les instructeurs de l’API Particulier devront, entre autres, vérifier si votre éditeur a les <External href='https://particulier.api.gouv.fr/faq#quels-sont-les-prerequis-techniques-pour-utiliser-l-api'>prérequis techniques</External> pour utiliser l’API Particulier.`,
+        },
     ],
   };
-  

--- a/components/questionTree/data/api-particulier/eligible.ts
+++ b/components/questionTree/data/api-particulier/eligible.ts
@@ -185,7 +185,7 @@ export const pathEligible = {
         `,
         },
         {
-          choices: ['**Mon éditeur ne figure pas dans cette liste**'],
+          choices: ['**Votre éditeur ne figure pas dans cette liste**'],
           answer: `**Vous êtes éligible mais votre éditeur n’a pas intégré l’API&nbsp;Particulier <span role="img" aria-label="émoji loupe">🔎</span>**
           <br/>
           Déposez une demande pour expliciter vos besoins et votre situation. L’équipe API Particulier vous contactera pour identifier des pistes de solutions, et contactera le cas échéant votre éditeur (pensez donc bien à préciser le nom de votre éditeur et ses coordonnées).

--- a/components/questionTree/data/api-particulier/index.ts
+++ b/components/questionTree/data/api-particulier/index.ts
@@ -1,26 +1,40 @@
 import { pathEligible } from './eligible';
 
 const apiParticulierQuestions = {
+
     apipart: {
     question: 'Qui sera en charge techniquement de l’intégration de l’API Particulier ?',
     choiceTree: [
-        {
+      {
         choices: [
-            'Mon éditeur de logiciel',
+          '**Nos développeurs internes.**<br/>Ils conçoivent une solution logicielle sur-mesure pour mon organisation.',
+          '**Nos développeurs prestataires.**<br/>Ils conçoivent une solution logicielle sur-mesure pour mon organisation.',
+        ],
+        answer: `**<span role='img' aria-label='émoji ok'>👍</span> Vous êtes éligible et avez les <External href='https://entreprise.api.gouv.fr/developpeurs#prerequis-techniques'>prérequis techniques</External> pour intégrer l’API Entreprise** à votre logiciel interne de traitement des démarches des associations et des entreprises.**
+        <br/><br/>
+        <Button href='https://datapass.api.gouv.fr/api-entreprise' target='_blank' rel="noreferrer noopener">Déposer une demande</Button>`,
+      },
+      {
+        choices: [
+          '**Mon éditeur.**<br/>Rien à coder, j’utilise une solution clé en main proposée par un éditeur.',
         ],
         next: pathEligible,
-        },
-        {
-            choices: [
-                'Mon équipe de développeurs (ou moi-même)',
-                'Autre / Je ne sais pas'
-            ],
-            answer: `<br/><Button href="https://datapass.api.gouv.fr/api-particulier">Remplir une demande</Button>
-            `,
-            },
+      },
+      {
+        choices: [
+          '**Je n’ai ni équipe technique, ni éditeur.**<br/>Actuellement, je contacte les particuliers un par un et traite leurs données à la main.',
+        ],
+        answer: `** Vous êtes éligible mais n'avez pas les <External href='https://particulier.api.gouv.fr/faq#quels-sont-les-prerequis-techniques-pour-utiliser-l-api'>prérequis techniques</External> pour utiliser l’API&nbsp;Particulier <span role='img' aria-label='émoji loupe'>🔎</span>**
+        <br/>
+        L’API Particulier s’utilise au travers d’un logiciel métier. Si vous collectez et traitez les données à la main, vous n’avez probablement pas un logiciel dédié aux démarches.
+        <br/>
+        **De nombreux éditeurs de logiciel, ont déjà intégré l'API Entreprise, nous vous recommandons d'en <External href='https://particulier.api.gouv.fr/faq#je-recherche-un-editeur-proposant-l-api-particulier'>consulter la liste</External>**.
+        <br/>
+        <br/>
+        <Button href='https://datapass.api.gouv.fr/api-entreprise' target='_blank' rel="noreferrer noopener" alt>Déposer tout de même une demande</Button>`,
+      },
     ],
 },
     } as { [key: string]: any };
-  
+
   export default apiParticulierQuestions;
-  

--- a/components/questionTree/data/api-particulier/index.ts
+++ b/components/questionTree/data/api-particulier/index.ts
@@ -9,7 +9,7 @@ const apiParticulierQuestions = {
         choices: [
           '**Vos développeurs internes.**<br/>Ils conçoivent une solution logicielle sur-mesure pour votre organisation.',
         ],
-        answer: `**<span role='img' aria-label='émoji ok'>👍</span> Vous êtes éligible et avez les <External href='https://particulier.api.gouv.fr/faq#quels-sont-les-prerequis-techniques-pour-utiliser-l-api'>prérequis techniques</External> pour intégrer l’API Entreprise** à votre logiciel interne de traitement des démarches des particuliers.**
+        answer: `**<span role='img' aria-label='émoji ok'>👍</span> Vous êtes éligible et avez les <External href='https://particulier.api.gouv.fr/faq#quels-sont-les-prerequis-techniques-pour-utiliser-l-api'>prérequis techniques</External> pour intégrer l’API Particulier** à votre logiciel interne de traitement des démarches des particuliers.**
         <br/><br/>
         <Button href='https://datapass.api.gouv.fr/api-particulier' target='_blank' rel="noreferrer noopener">Déposer une demande</Button>`,
       },
@@ -17,7 +17,7 @@ const apiParticulierQuestions = {
         choices: [
           '**Vos développeurs prestataires.**<br/>Ils conçoivent une solution logicielle sur-mesure pour votre organisation.',
         ],
-        answer: `**<span role='img' aria-label='émoji ok'>👍</span> Vous êtes éligible et vos développeurs externes ont les <External href='https://particulier.api.gouv.fr/faq#quels-sont-les-prerequis-techniques-pour-utiliser-l-api'>prérequis techniques</External> pour intégrer l’API Entreprise** à votre logiciel interne de traitement des démarches des particuliers.**
+        answer: `**<span role='img' aria-label='émoji ok'>👍</span> Vous êtes éligible et vos développeurs externes ont les <External href='https://particulier.api.gouv.fr/faq#quels-sont-les-prerequis-techniques-pour-utiliser-l-api'>prérequis techniques</External> pour intégrer l’API Particulier** à votre logiciel interne de traitement des démarches des particuliers.**
         <br/><br/>
         <Button href='https://datapass.api.gouv.fr/api-particulier' target='_blank' rel="noreferrer noopener">Déposer une demande</Button>`,
       },
@@ -35,7 +35,7 @@ const apiParticulierQuestions = {
         <br/>
         <span role='img' aria-label='émoji loupe'>🔎</span>&nbsp;L’API Particulier s’utilise au travers d’un logiciel métier. Si vous collectez et traitez les données à la main, vous n’avez probablement pas un logiciel dédié aux démarches.
         <br/>
-        **De nombreux éditeurs de logiciel, ont déjà intégré l'API Entreprise, nous vous recommandons d'en <External href='https://particulier.api.gouv.fr/faq#je-recherche-un-editeur-proposant-l-api-particulier'>consulter la liste</External>**.
+        **De nombreux éditeurs de logiciel, ont déjà intégré l'API Particulier, nous vous recommandons d'en <External href='https://particulier.api.gouv.fr/faq#je-recherche-un-editeur-proposant-l-api-particulier'>consulter la liste</External>**.
         <br/>
         <br/>
         <Button href='https://datapass.api.gouv.fr/api-entreprise' target='_blank' rel="noreferrer noopener" alt>Déposer tout de même une demande</Button>`,

--- a/components/questionTree/data/api-particulier/index.ts
+++ b/components/questionTree/data/api-particulier/index.ts
@@ -7,26 +7,33 @@ const apiParticulierQuestions = {
     choiceTree: [
       {
         choices: [
-          '**Nos développeurs internes.**<br/>Ils conçoivent une solution logicielle sur-mesure pour mon organisation.',
-          '**Nos développeurs prestataires.**<br/>Ils conçoivent une solution logicielle sur-mesure pour mon organisation.',
+          '**Vos développeurs internes.**<br/>Ils conçoivent une solution logicielle sur-mesure pour votre organisation.',
         ],
-        answer: `**<span role='img' aria-label='émoji ok'>👍</span> Vous êtes éligible et avez les <External href='https://entreprise.api.gouv.fr/developpeurs#prerequis-techniques'>prérequis techniques</External> pour intégrer l’API Entreprise** à votre logiciel interne de traitement des démarches des associations et des entreprises.**
+        answer: `**<span role='img' aria-label='émoji ok'>👍</span> Vous êtes éligible et avez les <External href='https://particulier.api.gouv.fr/faq#quels-sont-les-prerequis-techniques-pour-utiliser-l-api'>prérequis techniques</External> pour intégrer l’API Entreprise** à votre logiciel interne de traitement des démarches des particuliers.**
         <br/><br/>
-        <Button href='https://datapass.api.gouv.fr/api-entreprise' target='_blank' rel="noreferrer noopener">Déposer une demande</Button>`,
+        <Button href='https://datapass.api.gouv.fr/api-particulier' target='_blank' rel="noreferrer noopener">Déposer une demande</Button>`,
       },
       {
         choices: [
-          '**Mon éditeur.**<br/>Rien à coder, j’utilise une solution clé en main proposée par un éditeur.',
+          '**Vos développeurs prestataires.**<br/>Ils conçoivent une solution logicielle sur-mesure pour votre organisation.',
+        ],
+        answer: `**<span role='img' aria-label='émoji ok'>👍</span> Vous êtes éligible et vos développeurs externes ont les <External href='https://particulier.api.gouv.fr/faq#quels-sont-les-prerequis-techniques-pour-utiliser-l-api'>prérequis techniques</External> pour intégrer l’API Entreprise** à votre logiciel interne de traitement des démarches des particuliers.**
+        <br/><br/>
+        <Button href='https://datapass.api.gouv.fr/api-particulier' target='_blank' rel="noreferrer noopener">Déposer une demande</Button>`,
+      },
+      {
+        choices: [
+          '**Votre éditeur.**<br/>Rien à coder, vous utilisez une solution clé en main proposée par un éditeur.',
         ],
         next: pathEligible,
       },
       {
         choices: [
-          '**Je n’ai ni équipe technique, ni éditeur.**<br/>Actuellement, je contacte les particuliers un par un et traite leurs données à la main.',
+          '**Ni équipe technique, ni éditeur.**<br/>Actuellement, vous contactez les particuliers un par un et traitez leurs données à la main.',
         ],
-        answer: `** Vous êtes éligible mais n'avez pas les <External href='https://particulier.api.gouv.fr/faq#quels-sont-les-prerequis-techniques-pour-utiliser-l-api'>prérequis techniques</External> pour utiliser l’API&nbsp;Particulier <span role='img' aria-label='émoji loupe'>🔎</span>**
+        answer: `** Vous êtes éligible mais n'avez pas les <External href='https://particulier.api.gouv.fr/faq#quels-sont-les-prerequis-techniques-pour-utiliser-l-api'>prérequis techniques</External> pour utiliser l’API&nbsp;Particulier**
         <br/>
-        L’API Particulier s’utilise au travers d’un logiciel métier. Si vous collectez et traitez les données à la main, vous n’avez probablement pas un logiciel dédié aux démarches.
+        <span role='img' aria-label='émoji loupe'>🔎</span>&nbsp;L’API Particulier s’utilise au travers d’un logiciel métier. Si vous collectez et traitez les données à la main, vous n’avez probablement pas un logiciel dédié aux démarches.
         <br/>
         **De nombreux éditeurs de logiciel, ont déjà intégré l'API Entreprise, nous vous recommandons d'en <External href='https://particulier.api.gouv.fr/faq#je-recherche-un-editeur-proposant-l-api-particulier'>consulter la liste</External>**.
         <br/>

--- a/components/richReactMarkdown/index.tsx
+++ b/components/richReactMarkdown/index.tsx
@@ -39,7 +39,7 @@ const Grid: React.FC<PropsWithChildren<{}>> = props => (
 
 const NextSteps = ({
   is_editeur = false,
-  service_description = `de la description du service justifiant une simplification pour les citoyens`,
+  service_description = `de la description du service justifiant une simplification pour les usagers`,
 }) => (
   <>
     <p>
@@ -47,8 +47,8 @@ const NextSteps = ({
     </p>
     <ul>
       <li>de votre numéro SIRET</li>
-      <li>du cadre juridique</li>
       <li>{service_description}</li>
+      <li>du cadre juridique</li>
       <li>des coordonnées de l'équipe</li>
       <li>
         des coordonnées de votre délégué à la protection des données et


### PR DESCRIPTION
### Ce que cette PR permet : 

Désormais API particulier et API Entreprise ont les mêmes choix de niveau 0 à savoir les réponses à "Qui êtes-vous ?"

API Particulier bénéficie désormais des précisions disponibles pour API Entreprise concernant la question "Qui sera en charge techniquement de l'API ?"

API Entreprise bénéficie désormais d'un accès direct vers les formulaires des éditeurs qui ont un formulaire pré-rempli.

### Ce que cette API n'harmonise pas :

Du côté d'API Entreprise on continue de délivrer des jetons à certains éditeurs et donc on leur propose un formulaire pré-rempli.

=> Est-ce qu'on veut garder ce process ?
=> Ça veut aussi dire que j'ai du garder l'option "Votre éditeur a déjà un accès, adressez vous directement à lui" dans l'arbre de sélection de l'éditeur.


Du côté d'API Partculier, on les renvoie vers un Typeform car aucun éditeur n'a d'accès.