### PR TITLE
Compute datagouv link

### DIFF
--- a/_data/api/template.api-fermees.md.example
+++ b/_data/api/template.api-fermees.md.example
@@ -75,12 +75,6 @@ last_update: 11/10/2023 # Date de la dernière mise à jour de la doc
 datagouv_uuid: # Si l'API se base sur un jeu de données ouvertes accessibles depuis data.gouv.fr, ajouter l'uuid du jeu de données pour afficher automatiquement un bloc en fin de page référençant le jeu de données.
   - 631f4320d215a236920bd4dd
 content_intro: |
-  <div style="background-color:#FFE9E6; color: #B34000; padding:1rem">
-    <strong>⚠️ Ces informations ne sont plus mises à jour depuis le 06/09/2024.</strong><br>
-    Le site API.gouv.fr va progressivement être fusionné dans le catalogue unique data.gouv.fr. <br>
-    Retrouvez la fiche d'information à jour de cette API sur la nouvelle page API de Data.gouv.fr <a href="TODO" target="_blank" rel="noopener noreferrer">⇢ Consulter la fiche à jour</a>
-  </div>
-
   ### À quoi sert l'API XXX ?
 
   L'<External href="https://URL">API XXX</External> délivre les informations et documents de référence de XXX, informations issues du répertoire XXX et de la base YYY.

--- a/_data/api/template.api-opendata.md.example
+++ b/_data/api/template.api-opendata.md.example
@@ -43,12 +43,6 @@ keywords: # 📍 Ajouter des mots clés qui permettront aux usagers de trouver v
 last_update: 11/10/2023 # Date de la dernière mise à jour de la doc
 datagouv_uuid: # Si l'API se base sur un jeu de données ouvertes accessibles depuis data.gouv.fr, ajouter l'uuid du jeu de données pour afficher automatiquement un bloc en fin de page référençant le jeu de données.
 content_intro: |
-  <div style="background-color:#FFE9E6; color: #B34000; padding:1rem">
-    <strong>⚠️ Ces informations ne sont plus mises à jour depuis le 06/09/2024.</strong><br>
-    Le site API.gouv.fr va progressivement être fusionné dans le catalogue unique data.gouv.fr. <br>
-    Retrouvez la fiche d'information à jour de cette API sur la nouvelle page API de Data.gouv.fr <a href="TODO" target="_blank" rel="noopener noreferrer">⇢ Consulter la fiche à jour</a>
-  </div>
-
   ### À quoi sert l'API XXX ?
 
   L'<External href="https://URL">API XXX</External> délivre les informations et documents de référence de XXX, informations issues du répertoire XXX et de la base YYY.

--- a/components/api/apiDescription.tsx
+++ b/components/api/apiDescription.tsx
@@ -4,14 +4,22 @@ import RichReactMarkdown from '../../components/richReactMarkdown';
 import Section from '../../components/api/section';
 import { IGuideElementShort } from '../../model';
 import { H3WithAnchor } from '../../uiComponents/titleWithAnchor';
+import { kebabCase } from 'lodash';
 
 const ApiDescription: React.FC<{
   content_intro?: string;
   body: string;
   guides: IGuideElementShort[];
-}> = ({ content_intro, guides, body }) => (
+  title: string;
+}> = ({ content_intro, guides, body, title }) => (
   <Section id="api-description" title="Description">
     <>
+      <div style={{backgroundColor: "#FFE9E6", color: "#B34000", padding: "1rem"}}>
+        <strong>⚠️ Ces informations ne sont plus mises à jour depuis le 06/09/2024.</strong><br />
+        Le site API.gouv.fr va progressivement être fusionné dans le catalogue unique data.gouv.fr. <br /><br />
+        Retrouvez la fiche d'information à jour de cette API sur la nouvelle page API de Data.gouv.fr <a href={`https://data.gouv.fr/fr/dataservices/${kebabCase(title)}`} target="_blank" rel="noopener noreferrer">⇢ Consulter la fiche à jour</a>
+      </div>
+      
       {content_intro && <RichReactMarkdown source={content_intro} />}
       {guides.length > 0 && (
         <>

--- a/pages/les-api/[slug].tsx
+++ b/pages/les-api/[slug].tsx
@@ -90,6 +90,7 @@ const API: React.FC<IProps> = ({ api, guides, datagouvDatasets }) => {
               guides={guides}
               body={body}
               content_intro={content_intro}
+              title={title}
             />
 
             {datagouvDatasets.length > 0 && (


### PR DESCRIPTION
J'ai ajouté le bloc d'aletre sur toutes les fiches, et je l'ai retiré des templates (il est automatiquement sur toutes les fiches maintenant).
J'ai vraiment bricolé ça, par ce que je connais pas tellement Next.js.

Voilà ce que ça donne : 

![image](https://github.com/user-attachments/assets/523b2536-2e9a-4884-bd52-23b82fff3b79)

Closes https://linear.app/pole-api/issue/API-3743/pouvoir-generer-le-lien-datagouv-correspondant
